### PR TITLE
Allow built-in schemas and fix null pointer issue

### DIFF
--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -80,7 +80,7 @@ func (x *addThreadsCmd) Execute(args []string) error {
 	setApi(x.Client)
 
 	var body []byte
-	if x.Schema != "" {
+	if x.Schema == "" {
 		if x.SchemaFile != "" {
 			path, err := homedir.Expand(string(x.SchemaFile))
 			if err != nil {

--- a/core/api_threads.go
+++ b/core/api_threads.go
@@ -51,7 +51,9 @@ func (a *api) addThreads(g *gin.Context) {
 	}
 
 	if opts["schema"] != "" {
-		config.Schema.Id = opts["schema"]
+		config.Schema = &pb.AddThreadConfig_Schema{
+			Id: opts["schema"],
+		}
 	}
 
 	config.Type = pb.Thread_Type(pbValForEnumString(pb.Thread_Type_value, opts["type"]))


### PR DESCRIPTION
Quick fix to allow built-in schemas to be specified (i.e., `--media`). Also addresses nul pointer issue which results from move to protobufs.