### PR TITLE
Safely catch invalid structs in Config API

### DIFF
--- a/core/api_config.go
+++ b/core/api_config.go
@@ -26,6 +26,9 @@ func getKeyValue(path string, object interface{}) (interface{}, error) {
 		}
 
 		v = v.FieldByName(key)
+		if !v.IsValid() {
+			return nil, fmt.Errorf("empty struct value")
+		}
 	}
 	return v.Interface(), nil
 }


### PR DESCRIPTION
Fixes #647. Now safely returns an error when an invalid key is used to access the config:

```
$ textile config Blah
empty struct value
```