### PR TITLE
Update fetch_release.sh

### DIFF
--- a/mobile/scripts/fetch_release.sh
+++ b/mobile/scripts/fetch_release.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 IOS_DIR="${DIR}/../dist/ios"
 ANDROID_DIR="${DIR}/../dist/android"


### PR DESCRIPTION
Stop script on first error with set -e. If tar fails mv will fail, making it harder to understand what failed. On a side note guys, my install was failing because $npm_package_version was undefined ($1 to script). This cause curl to fetch a non .gz file causing tar to fail. Probably an issue with my env, not sure. Should I open an issue?