### PR TITLE
repo: fix undefined structpb

### DIFF
--- a/repo/db/files.go
+++ b/repo/db/files.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/textileio/go-textile/pb"
 	"github.com/textileio/go-textile/repo"
 	"github.com/textileio/go-textile/util"


### PR DESCRIPTION
Was getting `repo/db/files.go:202:12: undefined: structpb` on `make build`.

Searching github for `structpb` returned imports like seen here. The latest VSCode tooling also suggested the change.