### PR TITLE
ci: add editorconfig and prettier

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -4,14 +4,14 @@ FROM golang:1.12.3
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 # install dependencies
-RUN apt-get update \
-    && apt-get install -y curl \
-    && apt-get install -y mingw-w64 \
-    && apt-get install -y zip \
-    && curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh \
-    && bash nodesource_setup.sh \
-    && apt-get install nodejs \
-    && apt-get -y autoclean
+RUN apt-get update &&
+	apt-get install -y curl &&
+	apt-get install -y mingw-w64 &&
+	apt-get install -y zip &&
+	curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh &&
+	bash nodesource_setup.sh &&
+	apt-get install nodejs &&
+	apt-get -y autoclean
 
 # add global node modules to path
 ENV PATH="/usr/lib/node_modules/yarn/bin:${PATH}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ checkout-linux: &checkout-linux
     at: /root
 
 jobs:
-
   persist-checkout:
     docker:
       - image: python
@@ -104,7 +103,7 @@ jobs:
 
   build-cli-darwin-windows:
     macos:
-      xcode: "10.1.0"
+      xcode: '10.1.0'
     environment:
       GOPATH: /Users/distiller/go
       GOROOT: /usr/local/go
@@ -187,7 +186,7 @@ jobs:
 
   build-ios-framework:
     macos:
-      xcode: "10.1.0"
+      xcode: '10.1.0'
     environment:
       GOPATH: /Users/distiller/go
       GOROOT: /usr/local/go

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# 2018 September 26
+# https://github.com/bevry/base
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+indent_style = tab
+
+[{*.mk,*.py}]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+indent_style = space
+indent_size = 4
+
+[{*.json,*.lsrules,*.yml,*.bowerrc,*.babelrc}]
+indent_style = space
+indent_size = 2
+
+[{*.json,*.lsrules}]
+insert_final_newline = true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Tray app (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+-   OS: [e.g. iOS]
+-   Browser [e.g. chrome, safari]
+-   Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+-   Device: [e.g. iPhone6]
+-   OS: [e.g. iOS8.1]
+-   Browser [e.g. stock browser, safari]
+-   Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -4,23 +4,28 @@ about: Track a large amount of work for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 ## Description
+
 Brief summary of what this Epic is, whether it's a larger project, goal, or user story. Describe the job to be done, which persona this Epic is mainly for, or if more multiple, break it down by user and job story.
 
 ## Initiative / goal
+
 Describe how this Epic impacts an initiative the business is working on.
 
 ### Hypothesis
+
 What is your hypothesis on the success of this Epic? Describe how success will be measured and what leading indicators the team will have to know if success has been hit.
 
 ## Acceptance criteria and must have scope
+
 Define what is a must-have for launch and in-scope. Keep this section fluid and dynamic until you lock-in priority during planning.
 
 ## Stakeholders
+
 Describe who needs to be kept up-to-date about this Epic, included in discussions, or updated along the way. Stakeholders can be both in Product/Engineering, as well as other teams like Customer Success who might want to keep customers updated on the Epic project.
 
 ## Timeline
+
 What's the timeline for this Epic, what resources are needed, and what might potentially block this from hitting the projected end date.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: enhancement
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,20 @@
 setup:
 	go get github.com/ahmetb/govvv
+	npm install
 
 test:
 	./test_compile.sh
 
 fmt:
+	echo 'Formatting with prettier...'
+	npx prettier --write "./**" 2> /dev/null || true
+	echo 'Formatting with goimports...'
 	goimports -w -l `find . -type f -name '*.go' -not -path './vendor/*'`
 
 lint:
+	echo 'Linting with prettier...'
+	npx prettier --check "./**" 2> /dev/null || true
+	echo 'Linting with golint...'
 	golint `go list ./... | grep -v /vendor/`
 
 build:

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -3,28 +3,28 @@ set -e
 user=textile
 repo="$TEXTILE_PATH"
 
-if [ `id -u` -eq 0 ]; then
-  echo "Changing user to $user"
-  # ensure folder is writable
-  su-exec "$user" test -w "$repo" || chown -R -- "$user" "$repo"
-  # restart script with new privileges
-  exec su-exec "$user" "$0" "$@"
+if [ $(id -u) -eq 0 ]; then
+	echo "Changing user to $user"
+	# ensure folder is writable
+	su-exec "$user" test -w "$repo" || chown -R -- "$user" "$repo"
+	# restart script with new privileges
+	exec su-exec "$user" "$0" "$@"
 fi
 
 # 2nd invocation with regular user
 textile version
 
 if [ -e "$repo/config" ]; then
-  echo "Found IPFS fs-repo at $repo"
+	echo "Found IPFS fs-repo at $repo"
 else
-  wallet=$(textile wallet init)
-  echo "$wallet"
-  textile init -s $(echo "$wallet" | tail -n1) $INIT_ARGS
+	wallet=$(textile wallet init)
+	echo "$wallet"
+	textile init -s $(echo "$wallet" | tail -n1) $INIT_ARGS
 fi
 
 # if the first argument is daemon
 if [ "$1" = "daemon" ]; then
-  shift
+	shift
 fi
 
 exec textile daemon "$@"

--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -49,7 +49,7 @@ There are several block types:
 -  FILES:    File(s) added.
 -  COMMENT:  Comment added to another block.
 -  LIKE:     Like added to another block.
-  
+
 Use this command to list and get blocks in a thread.`
 }
 

--- a/cmd/feed.go
+++ b/cmd/feed.go
@@ -39,7 +39,7 @@ The --mode option dictates how the feed is displayed:
 -  "stacks": Related blocks are chronologically grouped into "stacks". A new stack is started if an unrelated block
    breaks continuity. This mode is used by Textile Photos. Stacks may include:
 
-*  The initial post with some nested annotations. Newer annotations may have already been listed. 
+*  The initial post with some nested annotations. Newer annotations may have already been listed.
 *  One or more annotations about a post. The newest annotation assumes the "top" position in the stack. Additional
      annotations are nested under the target. Newer annotations may have already been listed in the case as well.
 

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -87,10 +87,10 @@ type addFilesCmd struct {
 func (x *addFilesCmd) Usage() string {
 	return `
 
-Adds a file or directory of files to a thread. Files not supported 
+Adds a file or directory of files to a thread. Files not supported
 by the thread schema are ignored. Nested directories are included.
 An existing file hash may also be used as input.
-Use the --group option to add directory files as a single object.  
+Use the --group option to add directory files as a single object.
 Omit the --thread option to use the default thread (if selected).`
 }
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -27,7 +27,7 @@ func (x *profileCmd) Short() string {
 }
 
 func (x *profileCmd) Long() string {
-	return ` 
+	return `
 Use this command to view and update the peer profile. A Textile account will
 show a profile for each of its peers, e.g., mobile, desktop, etc.
 `

--- a/cmd/tokens.go
+++ b/cmd/tokens.go
@@ -115,7 +115,7 @@ type rmTokensCmd struct {
 
 func (x *rmTokensCmd) Usage() string {
 	return `
-	
+
 	Removes an existing cafe token.`
 }
 

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -15,24 +15,24 @@ binpaths="/usr/local/bin /usr/bin"
 is_write_perm_missing=""
 
 for binpath in $binpaths; do
-  if mv "$bin" "$binpath/$bin" 2> /dev/null; then
-    echo "Moved $bin to $binpath"
-    exit 0
-  else
-    if [ -d "$binpath" -a ! -w "$binpath" ]; then
-      is_write_perm_missing=1
-    fi
-  fi
+	if mv "$bin" "$binpath/$bin" 2>/dev/null; then
+		echo "Moved $bin to $binpath"
+		exit 0
+	else
+		if [ -d "$binpath" -a ! -w "$binpath" ]; then
+			is_write_perm_missing=1
+		fi
+	fi
 done
 
 echo "We cannot install $bin in one of the directories $binpaths"
 
 if [ -n "$is_write_perm_missing" ]; then
-  echo "It seems that we do not have the necessary write permissions."
-  echo "Perhaps try running this script as a privileged user:"
-  echo
-  echo "    sudo $0"
-  echo
+	echo "It seems that we do not have the necessary write permissions."
+	echo "Perhaps try running this script as a privileged user:"
+	echo
+	echo "    sudo $0"
+	echo
 fi
 
 exit 1

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,3428 +1,3156 @@
 {
-    "swagger": "2.0",
-    "info": {
-        "description": "Textile's HTTP REST API Documentation",
-        "title": "Textile REST API",
-        "termsOfService": "https://github.com/textileio/go-textile/blob/master/TERMS",
-        "contact": {
-            "name": "Textile",
-            "url": "https://textile.io/",
-            "email": "contact@textile.io"
-        },
-        "license": {
-            "name": "MIT License",
-            "url": "https://github.com/textileio/go-textile/blob/master/LICENSE"
-        },
-        "version": "0"
+  "swagger": "2.0",
+  "info": {
+    "description": "Textile's HTTP REST API Documentation",
+    "title": "Textile REST API",
+    "termsOfService": "https://github.com/textileio/go-textile/blob/master/TERMS",
+    "contact": {
+      "name": "Textile",
+      "url": "https://textile.io/",
+      "email": "contact@textile.io"
     },
-    "host": "{{.Host}}",
-    "basePath": "/api/v0",
-    "paths": {
-        "/account": {
-            "get": {
-                "description": "Shows the local peer's account info as a contact",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "account"
-                ],
-                "summary": "Show account contact",
-                "responses": {
-                    "200": {
-                        "description": "contact",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Contact"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/account/address": {
-            "get": {
-                "description": "Shows the local peer's account address",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "account"
-                ],
-                "summary": "Show account address",
-                "responses": {
-                    "200": {
-                        "description": "address",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/account/seed": {
-            "get": {
-                "description": "Shows the local peer's account seed",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "account"
-                ],
-                "summary": "Show account seed",
-                "responses": {
-                    "200": {
-                        "description": "seed",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/blocks": {
-            "get": {
-                "description": "Paginates blocks in a thread. Blocks are the raw components in a thread.\nThink of them as an append-only log of thread updates where each update is\nhash-linked to its parent(s). New / recovering peers can sync history by simply\ntraversing the hash tree.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "Paginates blocks in a thread",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "thread=,offset=,limit=5",
-                        "description": "thread: Thread ID (can also use 'default'), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5)",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "blocks",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.BlockList"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/blocks/{id}": {
-            "get": {
-                "description": "Gets a thread block by ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "Gets thread block",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "block id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "block",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Block"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Removes a thread block by ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "Remove thread block",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "block id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "block",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Block"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/blocks/{id}/comment": {
-            "get": {
-                "description": "Gets a thread comment by block ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "Get thread comment",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "block id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "comment",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Comment"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/blocks/{id}/comments": {
-            "get": {
-                "description": "Lists comments on a thread block",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "List comments",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "block id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "comments",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.CommentList"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Adds a comment to a thread block",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "Add a comment",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "block id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "urlescaped comment body",
-                        "name": "X-Textile-Args",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "comment",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Comment"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/blocks/{id}/like": {
-            "get": {
-                "description": "Gets a thread like by block ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "Get thread like",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "block id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "like",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Like"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/blocks/{id}/likes": {
-            "get": {
-                "description": "Lists likes on a thread block",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "List likes",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "block id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "likes",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.LikeList"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Adds a like to a thread block",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "Add a like",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "block id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "like",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Like"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/cafes": {
-            "get": {
-                "description": "List info about all active cafe sessions. Cafes are other peers on the network\nwho offer pinning, backup, and inbox services",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "cafes"
-                ],
-                "summary": "List info about all active cafe sessions",
-                "responses": {
-                    "200": {
-                        "description": "cafe sessions",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.CafeSessionList"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Registers with a cafe and saves an expiring service session token. An access\ntoken is required to register, and should be obtained separately from the target\nCafe",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "cafes"
-                ],
-                "summary": "Register with a Cafe",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "cafe host",
-                        "name": "X-Textile-Args",
-                        "in": "header",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "token=",
-                        "description": "token: An access token supplied by the Cafe",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "cafe session",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.CafeSession"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/cafes/messages": {
-            "post": {
-                "description": "Check for messages at all cafes. New messages are downloaded and processed\nopportunistically.",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "cafes"
-                ],
-                "summary": "Check for messages at all cafes",
-                "responses": {
-                    "200": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/cafes/{id}": {
-            "get": {
-                "description": "Gets and displays info about a cafe session. Cafes are other peers on the network\nwho offer pinning, backup, and inbox services",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "cafes"
-                ],
-                "summary": "Gets and displays info about a cafe session",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "cafe id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "cafe session",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.CafeSession"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Deregisters with a cafe (content will expire based on the cafe's service rules)",
-                "tags": [
-                    "cafes"
-                ],
-                "summary": "Deregisters a cafe",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "cafe id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/config": {
-            "put": {
-                "description": "Replace entire config file contents. The config command controls configuration\nvariables. It works much like 'git config'. The configuration values are stored\nin a config file inside the Textile repository.",
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "config"
-                ],
-                "summary": "Replace config settings.",
-                "parameters": [
-                    {
-                        "description": "JSON document",
-                        "name": "config",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/mill.Json"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "description": "When patching config values, valid JSON types must be used. For example, a string\nshould be escaped or wrapped in single quotes (e.g., \\\"127.0.0.1:40600\\\") and\narrays and objects work fine (e.g. '{\"API\": \"127.0.0.1:40600\"}') but should be\nwrapped in single quotes. Be sure to restart the daemon for changes to take effect.\nSee https://tools.ietf.org/html/rfc6902 for details on RFC6902 JSON patch format.",
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "config"
-                ],
-                "summary": "Set/update config settings",
-                "parameters": [
-                    {
-                        "description": "An RFC6902 JSON patch (array of ops)",
-                        "name": "patch",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/mill.Json"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/config/{path}": {
-            "get": {
-                "description": "Report the currently active config settings, which may differ from the values\nspecifed when setting/patching values.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "config"
-                ],
-                "summary": "Get active config settings",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "config path (e.g., Addresses/API)",
-                        "name": "path",
-                        "in": "path"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "new config value",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/mill.Json"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/contacts": {
-            "get": {
-                "description": "Lists known contacts.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "contacts"
-                ],
-                "summary": "List known contacts",
-                "responses": {
-                    "200": {
-                        "description": "contacts",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.ContactList"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/contacts/search": {
-            "post": {
-                "description": "Search for contacts known locally and on the network",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "contacts"
-                ],
-                "summary": "Search for contacts",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "local=\"false\",limit=5,wait=5,address=,username=,events=\"false\"",
-                        "description": "local: Whether to only search local contacts, remote: Whether to only search remote contacts, limit: Stops searching after limit results are found, wait: Stops searching after 'wait' seconds have elapsed (max 30s), username: search by username string, address: search by account address string, events: Whether to emit Server-Sent Events (SSEvent) or plain JSON",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "results stream",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.QueryResult"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/contacts/{address}": {
-            "get": {
-                "description": "Gets a known contact",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "contacts"
-                ],
-                "summary": "Get a known contact",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "address",
-                        "name": "address",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "contact",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Contact"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "description": "Adds a contact by username or account address to known contacts.",
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "contacts"
-                ],
-                "summary": "Add to known contacts",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "address",
-                        "name": "address",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "contact",
-                        "name": "contact",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Contact"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Removes a known contact",
-                "tags": [
-                    "contacts"
-                ],
-                "summary": "Remove a contact",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "address",
-                        "name": "address",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/feed": {
-            "get": {
-                "description": "Paginates post (join|leave|files|message) and annotation (comment|like) block types\nThe mode option dictates how the feed is displayed:\n\"chrono\": All feed block types are shown. Annotations always nest their target post,\ni.e., the post a comment is about.\n\"annotated\": Annotations are nested under post targets, but are not shown in the\ntop-level feed.\n\"stacks\": Related blocks are chronologically grouped into \"stacks\". A new stack is\nstarted if an unrelated block breaks continuity. This mode is used by Textile\nPhotos. Stacks may include:\n* The initial post with some nested annotations. Newer annotations may have already\nbeen listed.\n* One or more annotations about a post. The newest annotation assumes the \"top\"\nposition in the stack. Additional annotations are nested under the target.\nNewer annotations may have already been listed in the case as well.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "feed"
-                ],
-                "summary": "Paginates post and annotation block types",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "thread=,offset=,limit=5,mode=\"chrono\"",
-                        "description": "thread: Thread ID (can also use 'default'), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5), mode: Feed mode (one of 'chrono', 'annotated', or 'stacks')",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "feed",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.FeedItemList"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/files": {
-            "get": {
-                "description": "Paginates thread files. If thread id not provided, paginate all files. Specify\n\"default\" to use the default thread (if set).",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "Paginates thread files",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "thread=,offset=,limit=5",
-                        "description": "thread: Thread ID. Omit for all, offset: Offset ID to start listing from. Omit for latest, limit: List page size. (default: 5)",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "files",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.FilesList"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/files/{block}": {
-            "get": {
-                "description": "Gets a thread file by block ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "Get thread file",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "block id",
-                        "name": "block",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "file",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Files"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/invites": {
-            "get": {
-                "description": "Lists all pending thread invites",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "invites"
-                ],
-                "summary": "List invites",
-                "responses": {
-                    "200": {
-                        "description": "invites",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.InviteViewList"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Creates a direct account-to-account or external invite to a thread",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "invites"
-                ],
-                "summary": "Create an invite to a thread",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "thread=,address=",
-                        "description": "thread: Thread ID (can also use 'default'), address: Account Address (omit to create an external invite)",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "invite",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.ExternalInvite"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/invites/{id}/accept": {
-            "post": {
-                "description": "Accepts a direct peer-to-peer or external invite to a thread. Use the key option\nwith an external invite",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "invites"
-                ],
-                "summary": "Accept a thread invite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "invite id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "key=",
-                        "description": "key: key for an external invite",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "join block",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Block"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/invites/{id}/ignore": {
-            "post": {
-                "description": "Ignores a direct peer-to-peer invite to a thread",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "invites"
-                ],
-                "summary": "Ignore a thread invite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "invite id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/ipfs/cat/{path}": {
-            "get": {
-                "description": "Displays the data behind an IPFS CID (hash) or Path",
-                "produces": [
-                    "application/octet-stream"
-                ],
-                "tags": [
-                    "ipfs"
-                ],
-                "summary": "Cat IPFS data",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "ipfs/ipns cid",
-                        "name": "path",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "key=",
-                        "description": "key: Key to decrypt data on-the-fly",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "data",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "integer"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/ipfs/id": {
-            "get": {
-                "description": "Displays underlying IPFS peer ID",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "ipfs"
-                ],
-                "summary": "Get IPFS peer ID",
-                "responses": {
-                    "200": {
-                        "description": "peer id",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/ipfs/swarm/connect": {
-            "post": {
-                "description": "Opens a new direct connection to a peer using an IPFS multiaddr",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "ipfs"
-                ],
-                "summary": "Opens a new direct connection to a peer address",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "peer address",
-                        "name": "X-Textile-Args",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/ipfs/swarm/peers": {
-            "get": {
-                "description": "Lists the set of peers this node is connected to",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "ipfs"
-                ],
-                "summary": "List swarm peers",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "verbose=\"false\",latency=\"false\",streams=\"false\",direction=\"false\"",
-                        "description": "verbose: Display all extra information, latency: Also list information about latency to each peer, streams: Also list information about open streams for each peer, direction: Also list information about the direction of connection",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "connection",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/ipfs.ConnInfos"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/keys/{target}": {
-            "get": {
-                "description": "Shows file keys under the given target from an add",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "Show file keys",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "target id",
-                        "name": "target",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "keys",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Keys"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/logs/{subsystem}": {
-            "post": {
-                "description": "List or change the verbosity of one or all subsystems log output. Textile logs\npiggyback on the IPFS event logs",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "utils"
-                ],
-                "summary": "Access subsystem logs",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "subsystem logging identifier (omit for all)",
-                        "name": "subsystem",
-                        "in": "path"
-                    },
-                    {
-                        "type": "string",
-                        "default": "level=,tex-only=\"false\"",
-                        "description": "level: Log-level (one of: debug, info, warning, error, critical, or ",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "subsystems",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/core.SubsystemInfo"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/messages": {
-            "get": {
-                "description": "Paginates thread messages",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "messages"
-                ],
-                "summary": "Paginates thread messages",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "thread=,offset=,limit=10",
-                        "description": "thread: Thread ID (can also use 'default', omit for all), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5)",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "messages",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.TextList"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/messages/{block}": {
-            "get": {
-                "description": "Gets a thread message by block ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "messages"
-                ],
-                "summary": "Get thread message",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "block id",
-                        "name": "block",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "message",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Text"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/mills/blob": {
-            "post": {
-                "description": "Takes a binary data blob, and optionally encrypts it, before adding to IPFS,\nand returns a file object",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "mills"
-                ],
-                "summary": "Process raw data blobs",
-                "parameters": [
-                    {
-                        "type": "file",
-                        "description": "multipart/form-data file",
-                        "name": "file",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
-                        "default": "plaintext=false,use=\"\"",
-                        "description": "plaintext: whether to leave unencrypted), use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "file",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.FileIndex"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/mills/image/exif": {
-            "post": {
-                "description": "Takes an input image, and extracts its EXIF data (optionally encrypting output),\nbefore adding to IPFS, and returns a file object",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "mills"
-                ],
-                "summary": "Extract EXIF data from image",
-                "parameters": [
-                    {
-                        "type": "file",
-                        "description": "multipart/form-data file",
-                        "name": "file",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
-                        "default": "plaintext=false,use=\"\"",
-                        "description": "plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "file",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.FileIndex"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/mills/image/resize": {
-            "post": {
-                "description": "Takes an input image, and resizes/resamples it (optionally encrypting output),\nbefore adding to IPFS, and returns a file object",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "mills"
-                ],
-                "summary": "Resize an image",
-                "parameters": [
-                    {
-                        "type": "file",
-                        "description": "multipart/form-data file",
-                        "name": "file",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
-                        "default": "plaintext=false,use=\"\",quality=75,width=100",
-                        "description": "plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS, width: the requested image width (required), quality: the requested JPEG image quality",
-                        "name": "X-Textile-Opts",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "file",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.FileIndex"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/mills/json": {
-            "post": {
-                "description": "Takes an input JSON document, validates it according to its schema.org definition,\noptionally encrypts the output before adding to IPFS, and returns a file object",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "mills"
-                ],
-                "summary": "Process input JSON data",
-                "parameters": [
-                    {
-                        "type": "file",
-                        "description": "multipart/form-data file",
-                        "name": "file",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
-                        "default": "plaintext=\"false\",use=\"\"",
-                        "description": "plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "file",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.FileIndex"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/mills/schema": {
-            "post": {
-                "description": "Takes a JSON-based Schema, validates it, adds it to IPFS, and returns a file object",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "mills"
-                ],
-                "summary": "Validate, add, and pin a new Schema",
-                "parameters": [
-                    {
-                        "description": "schema",
-                        "name": "schema",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Node"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "file",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.FileIndex"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/notifications": {
-            "get": {
-                "description": "Lists all notifications generated by thread and account activity.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "notifications"
-                ],
-                "summary": "List notifications",
-                "responses": {
-                    "200": {
-                        "description": "notifications",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.NotificationList"
-                        }
-                    }
-                }
-            }
-        },
-        "/notifications/{id}/read": {
-            "post": {
-                "description": "Marks a notifiction as read by ID. Use 'all' to mark all as read.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "notifications"
-                ],
-                "summary": "Mark notifiction as read",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "notification id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/ping": {
-            "get": {
-                "description": "Pings another peer on the network, returning online|offline.",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "utils"
-                ],
-                "summary": "Ping a network peer",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "peerid",
-                        "name": "X-Textile-Args",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "One of online|offline",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/profile": {
-            "get": {
-                "description": "Gets the local node's public profile",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "profile"
-                ],
-                "summary": "Get public profile",
-                "responses": {
-                    "200": {
-                        "description": "peer",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Peer"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/profile/avatar": {
-            "post": {
-                "description": "Sets public profile avatar by specifying an existing image file hash",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "profile"
-                ],
-                "summary": "Set avatar",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "hash",
-                        "name": "X-Textile-Args",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/profile/name": {
-            "post": {
-                "description": "Sets public profile display name to given string",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "profile"
-                ],
-                "summary": "Set display name",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "name",
-                        "name": "X-Textile-Args",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/snapshots": {
-            "post": {
-                "description": "Snapshots all threads and pushes to registered cafes",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "threads"
-                ],
-                "summary": "Create thread snapshots",
-                "responses": {
-                    "201": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/snapshots/search": {
-            "post": {
-                "description": "Searches the network for thread snapshots",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "threads"
-                ],
-                "summary": "Search for thread snapshots",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "wait=5,events=\"false\"",
-                        "description": "wait: Stops searching after 'wait' seconds have elapsed (max 30s), events: Whether to emit Server-Sent Events (SSEvent) or plain JSON",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "results stream",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.QueryResult"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/subscribe/{id}": {
-            "get": {
-                "description": "Subscribes to updates in a thread or all threads. An update is generated\nwhen a new block is added to a thread. There are several update types:\nMERGE, IGNORE, FLAG, JOIN, ANNOUNCE, LEAVE, TEXT, FILES, COMMENT, LIKE",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "subscribe"
-                ],
-                "summary": "Subscribe to thread updates",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "thread id, omit to stream all events",
-                        "name": "id",
-                        "in": "path"
-                    },
-                    {
-                        "type": "string",
-                        "default": "type=,events=\"false\"",
-                        "description": "type: Or'd list of event types (e.g., FILES|COMMENTS|LIKES) or empty to include all types, events: Whether to emit Server-Sent Events (SSEvent) or plain JSON",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "stream of updates",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.FeedItem"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/summary": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "utils"
-                ],
-                "summary": "Get a summary of node data",
-                "responses": {
-                    "200": {
-                        "description": "summary",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Summary"
-                        }
-                    }
-                }
-            }
-        },
-        "/threads": {
-            "get": {
-                "description": "Lists all local threads, returning a ThreadList object",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "threads"
-                ],
-                "summary": "Lists info on all threads",
-                "responses": {
-                    "200": {
-                        "description": "threads",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.ThreadList"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Adds a new Thread with given name, type, and sharing and whitelist options, returning\na Thread object",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "threads"
-                ],
-                "summary": "Adds and joins a new thread",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "name",
-                        "name": "X-Textile-Args",
-                        "in": "header",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "type=private,sharing=not_shared,whitelist=",
-                        "description": "key: A locally unique key used by an app to identify this thread on recovery, schema: Existing Thread Schema IPFS CID, type: Set the thread type to one of 'private', 'read_only', 'public', or 'open', sharing: Set the thread sharing style to one of 'not_shared','invite_only', or 'shared', whitelist: An array of contact addresses. When supplied, the thread will not allow additional peers beyond those in array, useful for 1-1 chat/file sharing",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "thread",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Thread"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/threads/{id}": {
-            "get": {
-                "description": "Gets and displays info about a thread",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "threads"
-                ],
-                "summary": "Gets a thread",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "thread id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "thread",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Thread"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "description": "Adds or updates a thread directly, usually from a backup",
-                "tags": [
-                    "threads"
-                ],
-                "summary": "Add or update a thread directly",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "thread",
-                        "name": "thread",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Thread"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Leaves and removes a thread",
-                "tags": [
-                    "threads"
-                ],
-                "summary": "Leave and remove a thread",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "thread id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/threads/{id}/files": {
-            "post": {
-                "description": "Adds a file or directory of files to a thread. Files not supported by the thread\nschema are ignored. Nested directories are included. An existing file hash may\nalso be used as input.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "threads"
-                ],
-                "summary": "Adds a file or directory of files to a thread",
-                "parameters": [
-                    {
-                        "description": "list of milled dirs (output from mill endpoint)",
-                        "name": "dir",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.DirectoryList"
-                        }
-                    },
-                    {
-                        "type": "string",
-                        "default": "caption=",
-                        "description": "caption: Caption to add to file(s)",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "file",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Files"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/threads/{id}/messages": {
-            "post": {
-                "description": "Adds a message to a thread",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "threads"
-                ],
-                "summary": "Add a message",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "urlescaped message body",
-                        "name": "X-Textile-Args",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "message",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.Text"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/threads/{id}/name": {
-            "put": {
-                "description": "Renames a thread. Only initiators can rename a thread.",
-                "tags": [
-                    "threads"
-                ],
-                "summary": "Rename a thread",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "name",
-                        "name": "X-Textile-Args",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/threads/{id}/peers": {
-            "get": {
-                "description": "Lists all peers in a thread, optionally listing peers in the default thread",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "threads"
-                ],
-                "summary": "List all thread peers",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "thread id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "contacts",
-                        "schema": {
-                            "type": "object",
-                            "$ref": "#/definitions/pb.ContactList"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/tokens": {
-            "get": {
-                "description": "List info about all stored cafe tokens",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "tokens"
-                ],
-                "summary": "List local tokens",
-                "responses": {
-                    "200": {
-                        "description": "tokens",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Generates an access token (44 random bytes) and saves a bcrypt hashed version for\nfuture lookup. The response contains a base58 encoded version of the random bytes\ntoken. If the 'store' option is set to false, the token is generated, but not\nstored in the local Cafe db. Alternatively, an existing token can be added using\nby specifying the 'token' option.\nTokens allow other peers to register with a Cafe peer.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "tokens"
-                ],
-                "summary": "Create an access token",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "token=,store=\"true\"",
-                        "description": "token: Use existing token, rather than creating a new one, store: Whether to store the added/generated token to the local db",
-                        "name": "X-Textile-Opts",
-                        "in": "header"
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "token",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/tokens/{id}": {
-            "get": {
-                "description": "Check validity of existing cafe access token",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "tokens"
-                ],
-                "summary": "Check token validity",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "invite id",
-                        "name": "token",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Removes an existing cafe token",
-                "tags": [
-                    "tokens"
-                ],
-                "summary": "Removes a cafe token",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "token",
-                        "name": "token",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "ok",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        }
+    "license": {
+      "name": "MIT License",
+      "url": "https://github.com/textileio/go-textile/blob/master/LICENSE"
     },
-    "definitions": {
-        "core.SubsystemInfo": {
-            "type": "object",
-            "additionalProperties": {}
-        },
-        "ipfs.ConnInfos": {
-            "type": "object",
-            "properties": {
-                "peers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ipfs.connInfo"
-                    }
-                }
+    "version": "0"
+  },
+  "host": "{{.Host}}",
+  "basePath": "/api/v0",
+  "paths": {
+    "/account": {
+      "get": {
+        "description": "Shows the local peer's account info as a contact",
+        "produces": ["application/json"],
+        "tags": ["account"],
+        "summary": "Show account contact",
+        "responses": {
+          "200": {
+            "description": "contact",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Contact"
             }
-        },
-        "ipfs.connInfo": {
-            "type": "object",
-            "properties": {
-                "addr": {
-                    "type": "string"
-                },
-                "direction": {
-                    "type": "string"
-                },
-                "latency": {
-                    "type": "string"
-                },
-                "muxer": {
-                    "type": "string"
-                },
-                "peer": {
-                    "type": "string"
-                },
-                "streams": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ipfs.streamInfo"
-                    }
-                }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
             }
-        },
-        "ipfs.streamInfo": {
-            "type": "object",
-            "properties": {
-                "protocol": {
-                    "type": "string"
-                }
-            }
-        },
-        "mill.Json": {
-            "type": "object"
-        },
-        "pb.Block": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "body": {
-                    "type": "string"
-                },
-                "date": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "parents": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "target": {
-                    "type": "string"
-                },
-                "thread": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "integer"
-                },
-                "user": {
-                    "description": "view info",
-                    "type": "object",
-                    "$ref": "#/definitions/pb.User"
-                }
-            }
-        },
-        "pb.BlockList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Block"
-                    }
-                }
-            }
-        },
-        "pb.Cafe": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "api": {
-                    "type": "string"
-                },
-                "node": {
-                    "type": "string"
-                },
-                "peer": {
-                    "type": "string"
-                },
-                "protocol": {
-                    "type": "string"
-                },
-                "swarm": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
-        },
-        "pb.CafeSession": {
-            "type": "object",
-            "properties": {
-                "access": {
-                    "type": "string"
-                },
-                "cafe": {
-                    "type": "object",
-                    "$ref": "#/definitions/pb.Cafe"
-                },
-                "exp": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "refresh": {
-                    "type": "string"
-                },
-                "rexp": {
-                    "type": "string"
-                },
-                "subject": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "pb.CafeSessionList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.CafeSession"
-                    }
-                }
-            }
-        },
-        "pb.Comment": {
-            "type": "object",
-            "properties": {
-                "body": {
-                    "type": "string"
-                },
-                "date": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "target": {
-                    "type": "object",
-                    "$ref": "#/definitions/pb.FeedItem"
-                },
-                "user": {
-                    "type": "object",
-                    "$ref": "#/definitions/pb.User"
-                }
-            }
-        },
-        "pb.CommentList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Comment"
-                    }
-                }
-            }
-        },
-        "pb.Contact": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "avatar": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "peers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Peer"
-                    }
-                },
-                "threads": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "pb.ContactList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Contact"
-                    }
-                }
-            }
-        },
-        "pb.Directory": {
-            "type": "object",
-            "properties": {
-                "files": {
-                    "type": "object"
-                }
-            }
-        },
-        "pb.DirectoryList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Directory"
-                    }
-                }
-            }
-        },
-        "pb.ExternalInvite": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "inviter": {
-                    "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                }
-            }
-        },
-        "pb.FeedItem": {
-            "type": "object",
-            "properties": {
-                "block": {
-                    "type": "string"
-                },
-                "payload": {
-                    "type": "string"
-                },
-                "thread": {
-                    "type": "string"
-                }
-            }
-        },
-        "pb.FeedItemList": {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer"
-                },
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.FeedItem"
-                    }
-                },
-                "next": {
-                    "type": "string"
-                }
-            }
-        },
-        "pb.File": {
-            "type": "object",
-            "properties": {
-                "file": {
-                    "type": "object",
-                    "$ref": "#/definitions/pb.FileIndex"
-                },
-                "index": {
-                    "type": "integer"
-                },
-                "links": {
-                    "type": "object"
-                }
-            }
-        },
-        "pb.FileIndex": {
-            "type": "object",
-            "properties": {
-                "added": {
-                    "type": "string"
-                },
-                "checksum": {
-                    "type": "string"
-                },
-                "hash": {
-                    "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "media": {
-                    "type": "string"
-                },
-                "meta": {
-                    "type": "string"
-                },
-                "mill": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "opts": {
-                    "type": "string"
-                },
-                "size": {
-                    "type": "integer"
-                },
-                "source": {
-                    "type": "string"
-                },
-                "targets": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "pb.Files": {
-            "type": "object",
-            "properties": {
-                "block": {
-                    "type": "string"
-                },
-                "caption": {
-                    "type": "string"
-                },
-                "comments": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Comment"
-                    }
-                },
-                "date": {
-                    "type": "string"
-                },
-                "files": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.File"
-                    }
-                },
-                "likes": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Like"
-                    }
-                },
-                "target": {
-                    "type": "string"
-                },
-                "threads": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "user": {
-                    "type": "object",
-                    "$ref": "#/definitions/pb.User"
-                }
-            }
-        },
-        "pb.FilesList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Files"
-                    }
-                }
-            }
-        },
-        "pb.InviteView": {
-            "type": "object",
-            "properties": {
-                "date": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "inviter": {
-                    "type": "object",
-                    "$ref": "#/definitions/pb.User"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "pb.InviteViewList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.InviteView"
-                    }
-                }
-            }
-        },
-        "pb.Keys": {
-            "type": "object",
-            "properties": {
-                "files": {
-                    "type": "object"
-                }
-            }
-        },
-        "pb.Like": {
-            "type": "object",
-            "properties": {
-                "date": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "target": {
-                    "type": "object",
-                    "$ref": "#/definitions/pb.FeedItem"
-                },
-                "user": {
-                    "type": "object",
-                    "$ref": "#/definitions/pb.User"
-                }
-            }
-        },
-        "pb.LikeList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Like"
-                    }
-                }
-            }
-        },
-        "pb.Node": {
-            "type": "object",
-            "properties": {
-                "json_schema": {
-                    "type": "string"
-                },
-                "links": {
-                    "type": "object"
-                },
-                "mill": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "opts": {
-                    "type": "object"
-                },
-                "pin": {
-                    "type": "boolean"
-                },
-                "plaintext": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "pb.Notification": {
-            "type": "object",
-            "properties": {
-                "actor": {
-                    "type": "string"
-                },
-                "block": {
-                    "type": "string"
-                },
-                "body": {
-                    "type": "string"
-                },
-                "date": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "read": {
-                    "type": "boolean"
-                },
-                "subject": {
-                    "type": "string"
-                },
-                "subject_desc": {
-                    "type": "string"
-                },
-                "target": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "integer"
-                },
-                "user": {
-                    "description": "view info",
-                    "type": "object",
-                    "$ref": "#/definitions/pb.User"
-                }
-            }
-        },
-        "pb.NotificationList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Notification"
-                    }
-                }
-            }
-        },
-        "pb.Peer": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "avatar": {
-                    "type": "string"
-                },
-                "created": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "inboxes": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Cafe"
-                    }
-                },
-                "name": {
-                    "type": "string"
-                },
-                "updated": {
-                    "type": "string"
-                }
-            }
-        },
-        "pb.QueryResult": {
-            "type": "object",
-            "properties": {
-                "date": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "local": {
-                    "type": "boolean"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "pb.Summary": {
-            "type": "object",
-            "properties": {
-                "account_peer_count": {
-                    "type": "integer"
-                },
-                "address": {
-                    "type": "string"
-                },
-                "contact_count": {
-                    "type": "integer"
-                },
-                "files_count": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "thread_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "pb.Text": {
-            "type": "object",
-            "properties": {
-                "block": {
-                    "type": "string"
-                },
-                "body": {
-                    "type": "string"
-                },
-                "comments": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Comment"
-                    }
-                },
-                "date": {
-                    "type": "string"
-                },
-                "likes": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Like"
-                    }
-                },
-                "user": {
-                    "type": "object",
-                    "$ref": "#/definitions/pb.User"
-                }
-            }
-        },
-        "pb.TextList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Text"
-                    }
-                }
-            }
-        },
-        "pb.Thread": {
-            "type": "object",
-            "properties": {
-                "block_count": {
-                    "type": "integer"
-                },
-                "head": {
-                    "type": "string"
-                },
-                "head_block": {
-                    "description": "view info",
-                    "type": "object",
-                    "$ref": "#/definitions/pb.Block"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "initiator": {
-                    "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "peer_count": {
-                    "type": "integer"
-                },
-                "schema": {
-                    "type": "string"
-                },
-                "schema_node": {
-                    "type": "object",
-                    "$ref": "#/definitions/pb.Node"
-                },
-                "sharing": {
-                    "type": "integer"
-                },
-                "sk": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "state": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "integer"
-                },
-                "whitelist": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "pb.ThreadList": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/pb.Thread"
-                    }
-                }
-            }
-        },
-        "pb.User": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "avatar": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+          }
         }
+      }
+    },
+    "/account/address": {
+      "get": {
+        "description": "Shows the local peer's account address",
+        "produces": ["text/plain"],
+        "tags": ["account"],
+        "summary": "Show account address",
+        "responses": {
+          "200": {
+            "description": "address",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/account/seed": {
+      "get": {
+        "description": "Shows the local peer's account seed",
+        "produces": ["text/plain"],
+        "tags": ["account"],
+        "summary": "Show account seed",
+        "responses": {
+          "200": {
+            "description": "seed",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/blocks": {
+      "get": {
+        "description": "Paginates blocks in a thread. Blocks are the raw components in a thread.\nThink of them as an append-only log of thread updates where each update is\nhash-linked to its parent(s). New / recovering peers can sync history by simply\ntraversing the hash tree.",
+        "produces": ["application/json"],
+        "tags": ["blocks"],
+        "summary": "Paginates blocks in a thread",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "thread=,offset=,limit=5",
+            "description": "thread: Thread ID (can also use 'default'), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5)",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "blocks",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.BlockList"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/blocks/{id}": {
+      "get": {
+        "description": "Gets a thread block by ID",
+        "produces": ["application/json"],
+        "tags": ["blocks"],
+        "summary": "Gets thread block",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "block id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "block",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Block"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Removes a thread block by ID",
+        "produces": ["application/json"],
+        "tags": ["blocks"],
+        "summary": "Remove thread block",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "block id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "block",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Block"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/blocks/{id}/comment": {
+      "get": {
+        "description": "Gets a thread comment by block ID",
+        "produces": ["application/json"],
+        "tags": ["blocks"],
+        "summary": "Get thread comment",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "block id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "comment",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Comment"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/blocks/{id}/comments": {
+      "get": {
+        "description": "Lists comments on a thread block",
+        "produces": ["application/json"],
+        "tags": ["blocks"],
+        "summary": "List comments",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "block id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "comments",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.CommentList"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Adds a comment to a thread block",
+        "produces": ["application/json"],
+        "tags": ["blocks"],
+        "summary": "Add a comment",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "block id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "urlescaped comment body",
+            "name": "X-Textile-Args",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "comment",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Comment"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/blocks/{id}/like": {
+      "get": {
+        "description": "Gets a thread like by block ID",
+        "produces": ["application/json"],
+        "tags": ["blocks"],
+        "summary": "Get thread like",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "block id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "like",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Like"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/blocks/{id}/likes": {
+      "get": {
+        "description": "Lists likes on a thread block",
+        "produces": ["application/json"],
+        "tags": ["blocks"],
+        "summary": "List likes",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "block id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "likes",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.LikeList"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Adds a like to a thread block",
+        "produces": ["application/json"],
+        "tags": ["blocks"],
+        "summary": "Add a like",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "block id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "like",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Like"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/cafes": {
+      "get": {
+        "description": "List info about all active cafe sessions. Cafes are other peers on the network\nwho offer pinning, backup, and inbox services",
+        "produces": ["application/json"],
+        "tags": ["cafes"],
+        "summary": "List info about all active cafe sessions",
+        "responses": {
+          "200": {
+            "description": "cafe sessions",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.CafeSessionList"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Registers with a cafe and saves an expiring service session token. An access\ntoken is required to register, and should be obtained separately from the target\nCafe",
+        "produces": ["application/json"],
+        "tags": ["cafes"],
+        "summary": "Register with a Cafe",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "cafe host",
+            "name": "X-Textile-Args",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "token=",
+            "description": "token: An access token supplied by the Cafe",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "cafe session",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.CafeSession"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/cafes/messages": {
+      "post": {
+        "description": "Check for messages at all cafes. New messages are downloaded and processed\nopportunistically.",
+        "produces": ["text/plain"],
+        "tags": ["cafes"],
+        "summary": "Check for messages at all cafes",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/cafes/{id}": {
+      "get": {
+        "description": "Gets and displays info about a cafe session. Cafes are other peers on the network\nwho offer pinning, backup, and inbox services",
+        "produces": ["application/json"],
+        "tags": ["cafes"],
+        "summary": "Gets and displays info about a cafe session",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "cafe id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "cafe session",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.CafeSession"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Deregisters with a cafe (content will expire based on the cafe's service rules)",
+        "tags": ["cafes"],
+        "summary": "Deregisters a cafe",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "cafe id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/config": {
+      "put": {
+        "description": "Replace entire config file contents. The config command controls configuration\nvariables. It works much like 'git config'. The configuration values are stored\nin a config file inside the Textile repository.",
+        "consumes": ["application/json"],
+        "tags": ["config"],
+        "summary": "Replace config settings.",
+        "parameters": [
+          {
+            "description": "JSON document",
+            "name": "config",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/mill.Json"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "When patching config values, valid JSON types must be used. For example, a string\nshould be escaped or wrapped in single quotes (e.g., \\\"127.0.0.1:40600\\\") and\narrays and objects work fine (e.g. '{\"API\": \"127.0.0.1:40600\"}') but should be\nwrapped in single quotes. Be sure to restart the daemon for changes to take effect.\nSee https://tools.ietf.org/html/rfc6902 for details on RFC6902 JSON patch format.",
+        "consumes": ["application/json"],
+        "tags": ["config"],
+        "summary": "Set/update config settings",
+        "parameters": [
+          {
+            "description": "An RFC6902 JSON patch (array of ops)",
+            "name": "patch",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/mill.Json"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/config/{path}": {
+      "get": {
+        "description": "Report the currently active config settings, which may differ from the values\nspecifed when setting/patching values.",
+        "produces": ["application/json"],
+        "tags": ["config"],
+        "summary": "Get active config settings",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "config path (e.g., Addresses/API)",
+            "name": "path",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "new config value",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/mill.Json"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/contacts": {
+      "get": {
+        "description": "Lists known contacts.",
+        "produces": ["application/json"],
+        "tags": ["contacts"],
+        "summary": "List known contacts",
+        "responses": {
+          "200": {
+            "description": "contacts",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.ContactList"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/contacts/search": {
+      "post": {
+        "description": "Search for contacts known locally and on the network",
+        "produces": ["application/json"],
+        "tags": ["contacts"],
+        "summary": "Search for contacts",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "local=\"false\",limit=5,wait=5,address=,username=,events=\"false\"",
+            "description": "local: Whether to only search local contacts, remote: Whether to only search remote contacts, limit: Stops searching after limit results are found, wait: Stops searching after 'wait' seconds have elapsed (max 30s), username: search by username string, address: search by account address string, events: Whether to emit Server-Sent Events (SSEvent) or plain JSON",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "results stream",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.QueryResult"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/contacts/{address}": {
+      "get": {
+        "description": "Gets a known contact",
+        "produces": ["application/json"],
+        "tags": ["contacts"],
+        "summary": "Get a known contact",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "address",
+            "name": "address",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "contact",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Contact"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Adds a contact by username or account address to known contacts.",
+        "consumes": ["application/json"],
+        "tags": ["contacts"],
+        "summary": "Add to known contacts",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "address",
+            "name": "address",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "contact",
+            "name": "contact",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Contact"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Removes a known contact",
+        "tags": ["contacts"],
+        "summary": "Remove a contact",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "address",
+            "name": "address",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/feed": {
+      "get": {
+        "description": "Paginates post (join|leave|files|message) and annotation (comment|like) block types\nThe mode option dictates how the feed is displayed:\n\"chrono\": All feed block types are shown. Annotations always nest their target post,\ni.e., the post a comment is about.\n\"annotated\": Annotations are nested under post targets, but are not shown in the\ntop-level feed.\n\"stacks\": Related blocks are chronologically grouped into \"stacks\". A new stack is\nstarted if an unrelated block breaks continuity. This mode is used by Textile\nPhotos. Stacks may include:\n* The initial post with some nested annotations. Newer annotations may have already\nbeen listed.\n* One or more annotations about a post. The newest annotation assumes the \"top\"\nposition in the stack. Additional annotations are nested under the target.\nNewer annotations may have already been listed in the case as well.",
+        "produces": ["application/json"],
+        "tags": ["feed"],
+        "summary": "Paginates post and annotation block types",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "thread=,offset=,limit=5,mode=\"chrono\"",
+            "description": "thread: Thread ID (can also use 'default'), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5), mode: Feed mode (one of 'chrono', 'annotated', or 'stacks')",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "feed",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.FeedItemList"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/files": {
+      "get": {
+        "description": "Paginates thread files. If thread id not provided, paginate all files. Specify\n\"default\" to use the default thread (if set).",
+        "produces": ["application/json"],
+        "tags": ["files"],
+        "summary": "Paginates thread files",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "thread=,offset=,limit=5",
+            "description": "thread: Thread ID. Omit for all, offset: Offset ID to start listing from. Omit for latest, limit: List page size. (default: 5)",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "files",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.FilesList"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/files/{block}": {
+      "get": {
+        "description": "Gets a thread file by block ID",
+        "produces": ["application/json"],
+        "tags": ["files"],
+        "summary": "Get thread file",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "block id",
+            "name": "block",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "file",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Files"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/invites": {
+      "get": {
+        "description": "Lists all pending thread invites",
+        "produces": ["application/json"],
+        "tags": ["invites"],
+        "summary": "List invites",
+        "responses": {
+          "200": {
+            "description": "invites",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.InviteViewList"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a direct account-to-account or external invite to a thread",
+        "produces": ["application/json"],
+        "tags": ["invites"],
+        "summary": "Create an invite to a thread",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "thread=,address=",
+            "description": "thread: Thread ID (can also use 'default'), address: Account Address (omit to create an external invite)",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "invite",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.ExternalInvite"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/invites/{id}/accept": {
+      "post": {
+        "description": "Accepts a direct peer-to-peer or external invite to a thread. Use the key option\nwith an external invite",
+        "produces": ["application/json"],
+        "tags": ["invites"],
+        "summary": "Accept a thread invite",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "invite id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "key=",
+            "description": "key: key for an external invite",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "join block",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Block"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/invites/{id}/ignore": {
+      "post": {
+        "description": "Ignores a direct peer-to-peer invite to a thread",
+        "produces": ["application/json"],
+        "tags": ["invites"],
+        "summary": "Ignore a thread invite",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "invite id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/ipfs/cat/{path}": {
+      "get": {
+        "description": "Displays the data behind an IPFS CID (hash) or Path",
+        "produces": ["application/octet-stream"],
+        "tags": ["ipfs"],
+        "summary": "Cat IPFS data",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ipfs/ipns cid",
+            "name": "path",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "key=",
+            "description": "key: Key to decrypt data on-the-fly",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "data",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/ipfs/id": {
+      "get": {
+        "description": "Displays underlying IPFS peer ID",
+        "produces": ["text/plain"],
+        "tags": ["ipfs"],
+        "summary": "Get IPFS peer ID",
+        "responses": {
+          "200": {
+            "description": "peer id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/ipfs/swarm/connect": {
+      "post": {
+        "description": "Opens a new direct connection to a peer using an IPFS multiaddr",
+        "produces": ["application/json"],
+        "tags": ["ipfs"],
+        "summary": "Opens a new direct connection to a peer address",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "peer address",
+            "name": "X-Textile-Args",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/ipfs/swarm/peers": {
+      "get": {
+        "description": "Lists the set of peers this node is connected to",
+        "produces": ["application/json"],
+        "tags": ["ipfs"],
+        "summary": "List swarm peers",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "verbose=\"false\",latency=\"false\",streams=\"false\",direction=\"false\"",
+            "description": "verbose: Display all extra information, latency: Also list information about latency to each peer, streams: Also list information about open streams for each peer, direction: Also list information about the direction of connection",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "connection",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/ipfs.ConnInfos"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/keys/{target}": {
+      "get": {
+        "description": "Shows file keys under the given target from an add",
+        "produces": ["application/json"],
+        "tags": ["files"],
+        "summary": "Show file keys",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "target id",
+            "name": "target",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "keys",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Keys"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/logs/{subsystem}": {
+      "post": {
+        "description": "List or change the verbosity of one or all subsystems log output. Textile logs\npiggyback on the IPFS event logs",
+        "produces": ["application/json"],
+        "tags": ["utils"],
+        "summary": "Access subsystem logs",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "subsystem logging identifier (omit for all)",
+            "name": "subsystem",
+            "in": "path"
+          },
+          {
+            "type": "string",
+            "default": "level=,tex-only=\"false\"",
+            "description": "level: Log-level (one of: debug, info, warning, error, critical, or ",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "subsystems",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/core.SubsystemInfo"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/messages": {
+      "get": {
+        "description": "Paginates thread messages",
+        "produces": ["application/json"],
+        "tags": ["messages"],
+        "summary": "Paginates thread messages",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "thread=,offset=,limit=10",
+            "description": "thread: Thread ID (can also use 'default', omit for all), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5)",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "messages",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.TextList"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/messages/{block}": {
+      "get": {
+        "description": "Gets a thread message by block ID",
+        "produces": ["application/json"],
+        "tags": ["messages"],
+        "summary": "Get thread message",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "block id",
+            "name": "block",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "message",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Text"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/mills/blob": {
+      "post": {
+        "description": "Takes a binary data blob, and optionally encrypts it, before adding to IPFS,\nand returns a file object",
+        "consumes": ["multipart/form-data"],
+        "produces": ["application/json"],
+        "tags": ["mills"],
+        "summary": "Process raw data blobs",
+        "parameters": [
+          {
+            "type": "file",
+            "description": "multipart/form-data file",
+            "name": "file",
+            "in": "formData"
+          },
+          {
+            "type": "string",
+            "default": "plaintext=false,use=\"\"",
+            "description": "plaintext: whether to leave unencrypted), use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "file",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.FileIndex"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/mills/image/exif": {
+      "post": {
+        "description": "Takes an input image, and extracts its EXIF data (optionally encrypting output),\nbefore adding to IPFS, and returns a file object",
+        "consumes": ["multipart/form-data"],
+        "produces": ["application/json"],
+        "tags": ["mills"],
+        "summary": "Extract EXIF data from image",
+        "parameters": [
+          {
+            "type": "file",
+            "description": "multipart/form-data file",
+            "name": "file",
+            "in": "formData"
+          },
+          {
+            "type": "string",
+            "default": "plaintext=false,use=\"\"",
+            "description": "plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "file",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.FileIndex"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/mills/image/resize": {
+      "post": {
+        "description": "Takes an input image, and resizes/resamples it (optionally encrypting output),\nbefore adding to IPFS, and returns a file object",
+        "consumes": ["multipart/form-data"],
+        "produces": ["application/json"],
+        "tags": ["mills"],
+        "summary": "Resize an image",
+        "parameters": [
+          {
+            "type": "file",
+            "description": "multipart/form-data file",
+            "name": "file",
+            "in": "formData"
+          },
+          {
+            "type": "string",
+            "default": "plaintext=false,use=\"\",quality=75,width=100",
+            "description": "plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS, width: the requested image width (required), quality: the requested JPEG image quality",
+            "name": "X-Textile-Opts",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "file",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.FileIndex"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/mills/json": {
+      "post": {
+        "description": "Takes an input JSON document, validates it according to its schema.org definition,\noptionally encrypts the output before adding to IPFS, and returns a file object",
+        "consumes": ["multipart/form-data"],
+        "produces": ["application/json"],
+        "tags": ["mills"],
+        "summary": "Process input JSON data",
+        "parameters": [
+          {
+            "type": "file",
+            "description": "multipart/form-data file",
+            "name": "file",
+            "in": "formData"
+          },
+          {
+            "type": "string",
+            "default": "plaintext=\"false\",use=\"\"",
+            "description": "plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "file",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.FileIndex"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/mills/schema": {
+      "post": {
+        "description": "Takes a JSON-based Schema, validates it, adds it to IPFS, and returns a file object",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["mills"],
+        "summary": "Validate, add, and pin a new Schema",
+        "parameters": [
+          {
+            "description": "schema",
+            "name": "schema",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Node"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "file",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.FileIndex"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/notifications": {
+      "get": {
+        "description": "Lists all notifications generated by thread and account activity.",
+        "produces": ["application/json"],
+        "tags": ["notifications"],
+        "summary": "List notifications",
+        "responses": {
+          "200": {
+            "description": "notifications",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.NotificationList"
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}/read": {
+      "post": {
+        "description": "Marks a notifiction as read by ID. Use 'all' to mark all as read.",
+        "produces": ["application/json"],
+        "tags": ["notifications"],
+        "summary": "Mark notifiction as read",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "notification id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/ping": {
+      "get": {
+        "description": "Pings another peer on the network, returning online|offline.",
+        "produces": ["text/plain"],
+        "tags": ["utils"],
+        "summary": "Ping a network peer",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "peerid",
+            "name": "X-Textile-Args",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "One of online|offline",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/profile": {
+      "get": {
+        "description": "Gets the local node's public profile",
+        "produces": ["application/json"],
+        "tags": ["profile"],
+        "summary": "Get public profile",
+        "responses": {
+          "200": {
+            "description": "peer",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Peer"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/profile/avatar": {
+      "post": {
+        "description": "Sets public profile avatar by specifying an existing image file hash",
+        "produces": ["text/plain"],
+        "tags": ["profile"],
+        "summary": "Set avatar",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "hash",
+            "name": "X-Textile-Args",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/profile/name": {
+      "post": {
+        "description": "Sets public profile display name to given string",
+        "produces": ["text/plain"],
+        "tags": ["profile"],
+        "summary": "Set display name",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "name",
+            "name": "X-Textile-Args",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/snapshots": {
+      "post": {
+        "description": "Snapshots all threads and pushes to registered cafes",
+        "produces": ["application/json"],
+        "tags": ["threads"],
+        "summary": "Create thread snapshots",
+        "responses": {
+          "201": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/snapshots/search": {
+      "post": {
+        "description": "Searches the network for thread snapshots",
+        "produces": ["application/json"],
+        "tags": ["threads"],
+        "summary": "Search for thread snapshots",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "wait=5,events=\"false\"",
+            "description": "wait: Stops searching after 'wait' seconds have elapsed (max 30s), events: Whether to emit Server-Sent Events (SSEvent) or plain JSON",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "results stream",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.QueryResult"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/subscribe/{id}": {
+      "get": {
+        "description": "Subscribes to updates in a thread or all threads. An update is generated\nwhen a new block is added to a thread. There are several update types:\nMERGE, IGNORE, FLAG, JOIN, ANNOUNCE, LEAVE, TEXT, FILES, COMMENT, LIKE",
+        "produces": ["application/json"],
+        "tags": ["subscribe"],
+        "summary": "Subscribe to thread updates",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "thread id, omit to stream all events",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "type": "string",
+            "default": "type=,events=\"false\"",
+            "description": "type: Or'd list of event types (e.g., FILES|COMMENTS|LIKES) or empty to include all types, events: Whether to emit Server-Sent Events (SSEvent) or plain JSON",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "stream of updates",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.FeedItem"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/summary": {
+      "get": {
+        "produces": ["application/json"],
+        "tags": ["utils"],
+        "summary": "Get a summary of node data",
+        "responses": {
+          "200": {
+            "description": "summary",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Summary"
+            }
+          }
+        }
+      }
+    },
+    "/threads": {
+      "get": {
+        "description": "Lists all local threads, returning a ThreadList object",
+        "produces": ["application/json"],
+        "tags": ["threads"],
+        "summary": "Lists info on all threads",
+        "responses": {
+          "200": {
+            "description": "threads",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.ThreadList"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Adds a new Thread with given name, type, and sharing and whitelist options, returning\na Thread object",
+        "produces": ["application/json"],
+        "tags": ["threads"],
+        "summary": "Adds and joins a new thread",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "name",
+            "name": "X-Textile-Args",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "default": "type=private,sharing=not_shared,whitelist=",
+            "description": "key: A locally unique key used by an app to identify this thread on recovery, schema: Existing Thread Schema IPFS CID, type: Set the thread type to one of 'private', 'read_only', 'public', or 'open', sharing: Set the thread sharing style to one of 'not_shared','invite_only', or 'shared', whitelist: An array of contact addresses. When supplied, the thread will not allow additional peers beyond those in array, useful for 1-1 chat/file sharing",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "thread",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Thread"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/threads/{id}": {
+      "get": {
+        "description": "Gets and displays info about a thread",
+        "produces": ["application/json"],
+        "tags": ["threads"],
+        "summary": "Gets a thread",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "thread id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "thread",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Thread"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Adds or updates a thread directly, usually from a backup",
+        "tags": ["threads"],
+        "summary": "Add or update a thread directly",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "thread",
+            "name": "thread",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Thread"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Leaves and removes a thread",
+        "tags": ["threads"],
+        "summary": "Leave and remove a thread",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "thread id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/threads/{id}/files": {
+      "post": {
+        "description": "Adds a file or directory of files to a thread. Files not supported by the thread\nschema are ignored. Nested directories are included. An existing file hash may\nalso be used as input.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["threads"],
+        "summary": "Adds a file or directory of files to a thread",
+        "parameters": [
+          {
+            "description": "list of milled dirs (output from mill endpoint)",
+            "name": "dir",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.DirectoryList"
+            }
+          },
+          {
+            "type": "string",
+            "default": "caption=",
+            "description": "caption: Caption to add to file(s)",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "file",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Files"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/threads/{id}/messages": {
+      "post": {
+        "description": "Adds a message to a thread",
+        "produces": ["application/json"],
+        "tags": ["threads"],
+        "summary": "Add a message",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "urlescaped message body",
+            "name": "X-Textile-Args",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "message",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.Text"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/threads/{id}/name": {
+      "put": {
+        "description": "Renames a thread. Only initiators can rename a thread.",
+        "tags": ["threads"],
+        "summary": "Rename a thread",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name",
+            "name": "X-Textile-Args",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/threads/{id}/peers": {
+      "get": {
+        "description": "Lists all peers in a thread, optionally listing peers in the default thread",
+        "produces": ["application/json"],
+        "tags": ["threads"],
+        "summary": "List all thread peers",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "thread id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "contacts",
+            "schema": {
+              "type": "object",
+              "$ref": "#/definitions/pb.ContactList"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/tokens": {
+      "get": {
+        "description": "List info about all stored cafe tokens",
+        "produces": ["application/json"],
+        "tags": ["tokens"],
+        "summary": "List local tokens",
+        "responses": {
+          "200": {
+            "description": "tokens",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Generates an access token (44 random bytes) and saves a bcrypt hashed version for\nfuture lookup. The response contains a base58 encoded version of the random bytes\ntoken. If the 'store' option is set to false, the token is generated, but not\nstored in the local Cafe db. Alternatively, an existing token can be added using\nby specifying the 'token' option.\nTokens allow other peers to register with a Cafe peer.",
+        "produces": ["application/json"],
+        "tags": ["tokens"],
+        "summary": "Create an access token",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "token=,store=\"true\"",
+            "description": "token: Use existing token, rather than creating a new one, store: Whether to store the added/generated token to the local db",
+            "name": "X-Textile-Opts",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "token",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/tokens/{id}": {
+      "get": {
+        "description": "Check validity of existing cafe access token",
+        "produces": ["text/plain"],
+        "tags": ["tokens"],
+        "summary": "Check token validity",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "invite id",
+            "name": "token",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Removes an existing cafe token",
+        "tags": ["tokens"],
+        "summary": "Removes a cafe token",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "token",
+            "name": "token",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "ok",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
+  },
+  "definitions": {
+    "core.SubsystemInfo": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "ipfs.ConnInfos": {
+      "type": "object",
+      "properties": {
+        "peers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ipfs.connInfo"
+          }
+        }
+      }
+    },
+    "ipfs.connInfo": {
+      "type": "object",
+      "properties": {
+        "addr": {
+          "type": "string"
+        },
+        "direction": {
+          "type": "string"
+        },
+        "latency": {
+          "type": "string"
+        },
+        "muxer": {
+          "type": "string"
+        },
+        "peer": {
+          "type": "string"
+        },
+        "streams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ipfs.streamInfo"
+          }
+        }
+      }
+    },
+    "ipfs.streamInfo": {
+      "type": "object",
+      "properties": {
+        "protocol": {
+          "type": "string"
+        }
+      }
+    },
+    "mill.Json": {
+      "type": "object"
+    },
+    "pb.Block": {
+      "type": "object",
+      "properties": {
+        "author": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parents": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "target": {
+          "type": "string"
+        },
+        "thread": {
+          "type": "string"
+        },
+        "type": {
+          "type": "integer"
+        },
+        "user": {
+          "description": "view info",
+          "type": "object",
+          "$ref": "#/definitions/pb.User"
+        }
+      }
+    },
+    "pb.BlockList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Block"
+          }
+        }
+      }
+    },
+    "pb.Cafe": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "api": {
+          "type": "string"
+        },
+        "node": {
+          "type": "string"
+        },
+        "peer": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "swarm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "pb.CafeSession": {
+      "type": "object",
+      "properties": {
+        "access": {
+          "type": "string"
+        },
+        "cafe": {
+          "type": "object",
+          "$ref": "#/definitions/pb.Cafe"
+        },
+        "exp": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "refresh": {
+          "type": "string"
+        },
+        "rexp": {
+          "type": "string"
+        },
+        "subject": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "pb.CafeSessionList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.CafeSession"
+          }
+        }
+      }
+    },
+    "pb.Comment": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "target": {
+          "type": "object",
+          "$ref": "#/definitions/pb.FeedItem"
+        },
+        "user": {
+          "type": "object",
+          "$ref": "#/definitions/pb.User"
+        }
+      }
+    },
+    "pb.CommentList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Comment"
+          }
+        }
+      }
+    },
+    "pb.Contact": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "peers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Peer"
+          }
+        },
+        "threads": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "pb.ContactList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Contact"
+          }
+        }
+      }
+    },
+    "pb.Directory": {
+      "type": "object",
+      "properties": {
+        "files": {
+          "type": "object"
+        }
+      }
+    },
+    "pb.DirectoryList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Directory"
+          }
+        }
+      }
+    },
+    "pb.ExternalInvite": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "inviter": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "pb.FeedItem": {
+      "type": "object",
+      "properties": {
+        "block": {
+          "type": "string"
+        },
+        "payload": {
+          "type": "string"
+        },
+        "thread": {
+          "type": "string"
+        }
+      }
+    },
+    "pb.FeedItemList": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.FeedItem"
+          }
+        },
+        "next": {
+          "type": "string"
+        }
+      }
+    },
+    "pb.File": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "object",
+          "$ref": "#/definitions/pb.FileIndex"
+        },
+        "index": {
+          "type": "integer"
+        },
+        "links": {
+          "type": "object"
+        }
+      }
+    },
+    "pb.FileIndex": {
+      "type": "object",
+      "properties": {
+        "added": {
+          "type": "string"
+        },
+        "checksum": {
+          "type": "string"
+        },
+        "hash": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "media": {
+          "type": "string"
+        },
+        "meta": {
+          "type": "string"
+        },
+        "mill": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "opts": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "source": {
+          "type": "string"
+        },
+        "targets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "pb.Files": {
+      "type": "object",
+      "properties": {
+        "block": {
+          "type": "string"
+        },
+        "caption": {
+          "type": "string"
+        },
+        "comments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Comment"
+          }
+        },
+        "date": {
+          "type": "string"
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.File"
+          }
+        },
+        "likes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Like"
+          }
+        },
+        "target": {
+          "type": "string"
+        },
+        "threads": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "user": {
+          "type": "object",
+          "$ref": "#/definitions/pb.User"
+        }
+      }
+    },
+    "pb.FilesList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Files"
+          }
+        }
+      }
+    },
+    "pb.InviteView": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "inviter": {
+          "type": "object",
+          "$ref": "#/definitions/pb.User"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "pb.InviteViewList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.InviteView"
+          }
+        }
+      }
+    },
+    "pb.Keys": {
+      "type": "object",
+      "properties": {
+        "files": {
+          "type": "object"
+        }
+      }
+    },
+    "pb.Like": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "target": {
+          "type": "object",
+          "$ref": "#/definitions/pb.FeedItem"
+        },
+        "user": {
+          "type": "object",
+          "$ref": "#/definitions/pb.User"
+        }
+      }
+    },
+    "pb.LikeList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Like"
+          }
+        }
+      }
+    },
+    "pb.Node": {
+      "type": "object",
+      "properties": {
+        "json_schema": {
+          "type": "string"
+        },
+        "links": {
+          "type": "object"
+        },
+        "mill": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "opts": {
+          "type": "object"
+        },
+        "pin": {
+          "type": "boolean"
+        },
+        "plaintext": {
+          "type": "boolean"
+        }
+      }
+    },
+    "pb.Notification": {
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string"
+        },
+        "block": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "read": {
+          "type": "boolean"
+        },
+        "subject": {
+          "type": "string"
+        },
+        "subject_desc": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "type": {
+          "type": "integer"
+        },
+        "user": {
+          "description": "view info",
+          "type": "object",
+          "$ref": "#/definitions/pb.User"
+        }
+      }
+    },
+    "pb.NotificationList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Notification"
+          }
+        }
+      }
+    },
+    "pb.Peer": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "inboxes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Cafe"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string"
+        }
+      }
+    },
+    "pb.QueryResult": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "local": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "pb.Summary": {
+      "type": "object",
+      "properties": {
+        "account_peer_count": {
+          "type": "integer"
+        },
+        "address": {
+          "type": "string"
+        },
+        "contact_count": {
+          "type": "integer"
+        },
+        "files_count": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "string"
+        },
+        "thread_count": {
+          "type": "integer"
+        }
+      }
+    },
+    "pb.Text": {
+      "type": "object",
+      "properties": {
+        "block": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "comments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Comment"
+          }
+        },
+        "date": {
+          "type": "string"
+        },
+        "likes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Like"
+          }
+        },
+        "user": {
+          "type": "object",
+          "$ref": "#/definitions/pb.User"
+        }
+      }
+    },
+    "pb.TextList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Text"
+          }
+        }
+      }
+    },
+    "pb.Thread": {
+      "type": "object",
+      "properties": {
+        "block_count": {
+          "type": "integer"
+        },
+        "head": {
+          "type": "string"
+        },
+        "head_block": {
+          "description": "view info",
+          "type": "object",
+          "$ref": "#/definitions/pb.Block"
+        },
+        "id": {
+          "type": "string"
+        },
+        "initiator": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "peer_count": {
+          "type": "integer"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "schema_node": {
+          "type": "object",
+          "$ref": "#/definitions/pb.Node"
+        },
+        "sharing": {
+          "type": "integer"
+        },
+        "sk": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "state": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "integer"
+        },
+        "whitelist": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "pb.ThreadList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pb.Thread"
+          }
+        }
+      }
+    },
+    "pb.User": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
 }

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -1,21 +1,24 @@
 # Textile REST API
+
 Textile's HTTP REST API Documentation
 
 ## Version: 0
 
 ### Terms of service
+
 https://github.com/textileio/go-textile/blob/master/TERMS
 
-**Contact information:**  
-Textile  
-https://textile.io/  
-contact@textile.io  
+**Contact information:**
+Textile
+https://textile.io/
+contact@textile.io
 
 **License:** [MIT License](https://github.com/textileio/go-textile/blob/master/LICENSE)
 
 ### /account
 
 #### GET
+
 ##### Summary:
 
 Show account contact
@@ -26,14 +29,15 @@ Shows the local peer's account info as a contact
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | contact | [pb.Contact](#pb.contact) |
-| 400 | Bad Request | string |
+| Code | Description | Schema                    |
+| ---- | ----------- | ------------------------- |
+| 200  | contact     | [pb.Contact](#pb.contact) |
+| 400  | Bad Request | string                    |
 
 ### /account/address
 
 #### GET
+
 ##### Summary:
 
 Show account address
@@ -46,11 +50,12 @@ Shows the local peer's account address
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | address | string |
+| 200  | address     | string |
 
 ### /account/seed
 
 #### GET
+
 ##### Summary:
 
 Show account seed
@@ -63,11 +68,12 @@ Shows the local peer's account seed
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | seed | string |
+| 200  | seed        | string |
 
 ### /blocks
 
 #### GET
+
 ##### Summary:
 
 Paginates blocks in a thread
@@ -81,22 +87,23 @@ traversing the hash tree.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Opts | header | thread: Thread ID (can also use 'default'), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5) | No | string |
+| Name           | Located in | Description                                                                                                                               | Required | Schema |
+| -------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| X-Textile-Opts | header     | thread: Thread ID (can also use 'default'), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5) | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | blocks | [pb.BlockList](#pb.blocklist) |
-| 400 | Bad Request | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                        |
+| ---- | --------------------- | ----------------------------- |
+| 200  | blocks                | [pb.BlockList](#pb.blocklist) |
+| 400  | Bad Request           | string                        |
+| 404  | Not Found             | string                        |
+| 500  | Internal Server Error | string                        |
 
 ### /blocks/{id}
 
 #### DELETE
+
 ##### Summary:
 
 Remove thread block
@@ -108,19 +115,20 @@ Removes a thread block by ID
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | block id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | block id    | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | block | [pb.Block](#pb.block) |
-| 400 | Bad Request | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                |
+| ---- | --------------------- | --------------------- |
+| 201  | block                 | [pb.Block](#pb.block) |
+| 400  | Bad Request           | string                |
+| 404  | Not Found             | string                |
+| 500  | Internal Server Error | string                |
 
 #### GET
+
 ##### Summary:
 
 Gets thread block
@@ -132,19 +140,20 @@ Gets a thread block by ID
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | block id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | block id    | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | block | [pb.Block](#pb.block) |
-| 404 | Not Found | string |
+| Code | Description | Schema                |
+| ---- | ----------- | --------------------- |
+| 200  | block       | [pb.Block](#pb.block) |
+| 404  | Not Found   | string                |
 
 ### /blocks/{id}/comment
 
 #### GET
+
 ##### Summary:
 
 Get thread comment
@@ -156,19 +165,20 @@ Gets a thread comment by block ID
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | block id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | block id    | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | comment | [pb.Comment](#pb.comment) |
-| 400 | Bad Request | string |
+| Code | Description | Schema                    |
+| ---- | ----------- | ------------------------- |
+| 200  | comment     | [pb.Comment](#pb.comment) |
+| 400  | Bad Request | string                    |
 
 ### /blocks/{id}/comments
 
 #### GET
+
 ##### Summary:
 
 List comments
@@ -180,17 +190,18 @@ Lists comments on a thread block
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | block id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | block id    | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | comments | [pb.CommentList](#pb.commentlist) |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                            |
+| ---- | --------------------- | --------------------------------- |
+| 200  | comments              | [pb.CommentList](#pb.commentlist) |
+| 500  | Internal Server Error | string                            |
 
 #### POST
+
 ##### Summary:
 
 Add a comment
@@ -201,23 +212,24 @@ Adds a comment to a thread block
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | block id | Yes | string |
-| X-Textile-Args | header | urlescaped comment body | Yes | string |
+| Name           | Located in | Description             | Required | Schema |
+| -------------- | ---------- | ----------------------- | -------- | ------ |
+| id             | path       | block id                | Yes      | string |
+| X-Textile-Args | header     | urlescaped comment body | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | comment | [pb.Comment](#pb.comment) |
-| 400 | Bad Request | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                    |
+| ---- | --------------------- | ------------------------- |
+| 201  | comment               | [pb.Comment](#pb.comment) |
+| 400  | Bad Request           | string                    |
+| 404  | Not Found             | string                    |
+| 500  | Internal Server Error | string                    |
 
 ### /blocks/{id}/like
 
 #### GET
+
 ##### Summary:
 
 Get thread like
@@ -229,19 +241,20 @@ Gets a thread like by block ID
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | block id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | block id    | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | like | [pb.Like](#pb.like) |
-| 400 | Bad Request | string |
+| Code | Description | Schema              |
+| ---- | ----------- | ------------------- |
+| 200  | like        | [pb.Like](#pb.like) |
+| 400  | Bad Request | string              |
 
 ### /blocks/{id}/likes
 
 #### GET
+
 ##### Summary:
 
 List likes
@@ -253,17 +266,18 @@ Lists likes on a thread block
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | block id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | block id    | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | likes | [pb.LikeList](#pb.likelist) |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                      |
+| ---- | --------------------- | --------------------------- |
+| 200  | likes                 | [pb.LikeList](#pb.likelist) |
+| 500  | Internal Server Error | string                      |
 
 #### POST
+
 ##### Summary:
 
 Add a like
@@ -275,21 +289,22 @@ Adds a like to a thread block
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | block id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | block id    | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | like | [pb.Like](#pb.like) |
-| 400 | Bad Request | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema              |
+| ---- | --------------------- | ------------------- |
+| 201  | like                  | [pb.Like](#pb.like) |
+| 400  | Bad Request           | string              |
+| 404  | Not Found             | string              |
+| 500  | Internal Server Error | string              |
 
 ### /cafes
 
 #### GET
+
 ##### Summary:
 
 List info about all active cafe sessions
@@ -301,12 +316,13 @@ who offer pinning, backup, and inbox services
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | cafe sessions | [pb.CafeSessionList](#pb.cafesessionlist) |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                                    |
+| ---- | --------------------- | ----------------------------------------- |
+| 200  | cafe sessions         | [pb.CafeSessionList](#pb.cafesessionlist) |
+| 500  | Internal Server Error | string                                    |
 
 #### POST
+
 ##### Summary:
 
 Register with a Cafe
@@ -319,22 +335,23 @@ Cafe
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Args | header | cafe host | Yes | string |
-| X-Textile-Opts | header | token: An access token supplied by the Cafe | No | string |
+| Name           | Located in | Description                                 | Required | Schema |
+| -------------- | ---------- | ------------------------------------------- | -------- | ------ |
+| X-Textile-Args | header     | cafe host                                   | Yes      | string |
+| X-Textile-Opts | header     | token: An access token supplied by the Cafe | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | cafe session | [pb.CafeSession](#pb.cafesession) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                            |
+| ---- | --------------------- | --------------------------------- |
+| 201  | cafe session          | [pb.CafeSession](#pb.cafesession) |
+| 400  | Bad Request           | string                            |
+| 500  | Internal Server Error | string                            |
 
 ### /cafes/{id}
 
 #### DELETE
+
 ##### Summary:
 
 Deregisters a cafe
@@ -346,17 +363,18 @@ Deregisters with a cafe (content will expire based on the cafe's service rules)
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | cafe id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | cafe id     | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 204 | ok | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema |
+| ---- | --------------------- | ------ |
+| 204  | ok                    | string |
+| 500  | Internal Server Error | string |
 
 #### GET
+
 ##### Summary:
 
 Gets and displays info about a cafe session
@@ -369,20 +387,21 @@ who offer pinning, backup, and inbox services
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | cafe id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | cafe id     | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | cafe session | [pb.CafeSession](#pb.cafesession) |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                            |
+| ---- | --------------------- | --------------------------------- |
+| 200  | cafe session          | [pb.CafeSession](#pb.cafesession) |
+| 404  | Not Found             | string                            |
+| 500  | Internal Server Error | string                            |
 
 ### /cafes/messages
 
 #### POST
+
 ##### Summary:
 
 Check for messages at all cafes
@@ -394,14 +413,15 @@ opportunistically.
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | ok | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema |
+| ---- | --------------------- | ------ |
+| 200  | ok                    | string |
+| 500  | Internal Server Error | string |
 
 ### /config
 
 #### PATCH
+
 ##### Summary:
 
 Set/update config settings
@@ -416,18 +436,19 @@ See https://tools.ietf.org/html/rfc6902 for details on RFC6902 JSON patch format
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| patch | body | An RFC6902 JSON patch (array of ops) | Yes | [mill.Json](#mill.json) |
+| Name  | Located in | Description                          | Required | Schema                  |
+| ----- | ---------- | ------------------------------------ | -------- | ----------------------- |
+| patch | body       | An RFC6902 JSON patch (array of ops) | Yes      | [mill.Json](#mill.json) |
 
 ##### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 204 | No Content | string |
-| 400 | Bad Request | string |
+| 204  | No Content  | string |
+| 400  | Bad Request | string |
 
 #### PUT
+
 ##### Summary:
 
 Replace config settings.
@@ -440,20 +461,21 @@ in a config file inside the Textile repository.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| config | body | JSON document | Yes | [mill.Json](#mill.json) |
+| Name   | Located in | Description   | Required | Schema                  |
+| ------ | ---------- | ------------- | -------- | ----------------------- |
+| config | body       | JSON document | Yes      | [mill.Json](#mill.json) |
 
 ##### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 204 | No Content | string |
-| 400 | Bad Request | string |
+| 204  | No Content  | string |
+| 400  | Bad Request | string |
 
 ### /config/{path}
 
 #### GET
+
 ##### Summary:
 
 Get active config settings
@@ -465,20 +487,21 @@ specifed when setting/patching values.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| path | path | config path (e.g., Addresses/API) | No | string |
+| Name | Located in | Description                       | Required | Schema |
+| ---- | ---------- | --------------------------------- | -------- | ------ |
+| path | path       | config path (e.g., Addresses/API) | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | new config value | [mill.Json](#mill.json) |
-| 400 | Bad Request | string |
+| Code | Description      | Schema                  |
+| ---- | ---------------- | ----------------------- |
+| 200  | new config value | [mill.Json](#mill.json) |
+| 400  | Bad Request      | string                  |
 
 ### /contacts
 
 #### GET
+
 ##### Summary:
 
 List known contacts
@@ -489,15 +512,16 @@ Lists known contacts.
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | contacts | [pb.ContactList](#pb.contactlist) |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                            |
+| ---- | --------------------- | --------------------------------- |
+| 200  | contacts              | [pb.ContactList](#pb.contactlist) |
+| 404  | Not Found             | string                            |
+| 500  | Internal Server Error | string                            |
 
 ### /contacts/{address}
 
 #### DELETE
+
 ##### Summary:
 
 Remove a contact
@@ -508,19 +532,20 @@ Removes a known contact
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| address | path | address | Yes | string |
+| Name    | Located in | Description | Required | Schema |
+| ------- | ---------- | ----------- | -------- | ------ |
+| address | path       | address     | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 204 | ok | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema |
+| ---- | --------------------- | ------ |
+| 204  | ok                    | string |
+| 404  | Not Found             | string |
+| 500  | Internal Server Error | string |
 
 #### GET
+
 ##### Summary:
 
 Get a known contact
@@ -531,18 +556,19 @@ Gets a known contact
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| address | path | address | Yes | string |
+| Name    | Located in | Description | Required | Schema |
+| ------- | ---------- | ----------- | -------- | ------ |
+| address | path       | address     | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | contact | [pb.Contact](#pb.contact) |
-| 404 | Not Found | string |
+| Code | Description | Schema                    |
+| ---- | ----------- | ------------------------- |
+| 200  | contact     | [pb.Contact](#pb.contact) |
+| 404  | Not Found   | string                    |
 
 #### PUT
+
 ##### Summary:
 
 Add to known contacts
@@ -553,21 +579,22 @@ Adds a contact by username or account address to known contacts.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| address | path | address | Yes | string |
-| contact | body | contact | Yes | [pb.Contact](#pb.contact) |
+| Name    | Located in | Description | Required | Schema                    |
+| ------- | ---------- | ----------- | -------- | ------------------------- |
+| address | path       | address     | Yes      | string                    |
+| contact | body       | contact     | Yes      | [pb.Contact](#pb.contact) |
 
 ##### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 204 | ok | string |
-| 400 | Bad Request | string |
+| 204  | ok          | string |
+| 400  | Bad Request | string |
 
 ### /contacts/search
 
 #### POST
+
 ##### Summary:
 
 Search for contacts
@@ -578,21 +605,22 @@ Search for contacts known locally and on the network
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Opts | header | local: Whether to only search local contacts, remote: Whether to only search remote contacts, limit: Stops searching after limit results are found, wait: Stops searching after 'wait' seconds have elapsed (max 30s), username: search by username string, address: search by account address string, events: Whether to emit Server-Sent Events (SSEvent) or plain JSON | No | string |
+| Name           | Located in | Description                                                                                                                                                                                                                                                                                                                                                               | Required | Schema |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| X-Textile-Opts | header     | local: Whether to only search local contacts, remote: Whether to only search remote contacts, limit: Stops searching after limit results are found, wait: Stops searching after 'wait' seconds have elapsed (max 30s), username: search by username string, address: search by account address string, events: Whether to emit Server-Sent Events (SSEvent) or plain JSON | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | results stream | [pb.QueryResult](#pb.queryresult) |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                            |
+| ---- | --------------------- | --------------------------------- |
+| 200  | results stream        | [pb.QueryResult](#pb.queryresult) |
+| 404  | Not Found             | string                            |
+| 500  | Internal Server Error | string                            |
 
 ### /feed
 
 #### GET
+
 ##### Summary:
 
 Paginates post and annotation block types
@@ -608,30 +636,32 @@ top-level feed.
 "stacks": Related blocks are chronologically grouped into "stacks". A new stack is
 started if an unrelated block breaks continuity. This mode is used by Textile
 Photos. Stacks may include:
-* The initial post with some nested annotations. Newer annotations may have already
-been listed.
-* One or more annotations about a post. The newest annotation assumes the "top"
-position in the stack. Additional annotations are nested under the target.
-Newer annotations may have already been listed in the case as well.
+
+-   The initial post with some nested annotations. Newer annotations may have already
+    been listed.
+-   One or more annotations about a post. The newest annotation assumes the "top"
+    position in the stack. Additional annotations are nested under the target.
+    Newer annotations may have already been listed in the case as well.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Opts | header | thread: Thread ID (can also use 'default'), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5), mode: Feed mode (one of 'chrono', 'annotated', or 'stacks') | No | string |
+| Name           | Located in | Description                                                                                                                                                                                            | Required | Schema |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------ |
+| X-Textile-Opts | header     | thread: Thread ID (can also use 'default'), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5), mode: Feed mode (one of 'chrono', 'annotated', or 'stacks') | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | feed | [pb.FeedItemList](#pb.feeditemlist) |
-| 400 | Bad Request | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                              |
+| ---- | --------------------- | ----------------------------------- |
+| 200  | feed                  | [pb.FeedItemList](#pb.feeditemlist) |
+| 400  | Bad Request           | string                              |
+| 404  | Not Found             | string                              |
+| 500  | Internal Server Error | string                              |
 
 ### /files
 
 #### GET
+
 ##### Summary:
 
 Paginates thread files
@@ -643,22 +673,23 @@ Paginates thread files. If thread id not provided, paginate all files. Specify
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Opts | header | thread: Thread ID. Omit for all, offset: Offset ID to start listing from. Omit for latest, limit: List page size. (default: 5) | No | string |
+| Name           | Located in | Description                                                                                                                    | Required | Schema |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ | -------- | ------ |
+| X-Textile-Opts | header     | thread: Thread ID. Omit for all, offset: Offset ID to start listing from. Omit for latest, limit: List page size. (default: 5) | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | files | [pb.FilesList](#pb.fileslist) |
-| 400 | Bad Request | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                        |
+| ---- | --------------------- | ----------------------------- |
+| 200  | files                 | [pb.FilesList](#pb.fileslist) |
+| 400  | Bad Request           | string                        |
+| 404  | Not Found             | string                        |
+| 500  | Internal Server Error | string                        |
 
 ### /files/{block}
 
 #### GET
+
 ##### Summary:
 
 Get thread file
@@ -669,20 +700,21 @@ Gets a thread file by block ID
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| block | path | block id | Yes | string |
+| Name  | Located in | Description | Required | Schema |
+| ----- | ---------- | ----------- | -------- | ------ |
+| block | path       | block id    | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | file | [pb.Files](#pb.files) |
-| 400 | Bad Request | string |
+| Code | Description | Schema                |
+| ---- | ----------- | --------------------- |
+| 200  | file        | [pb.Files](#pb.files) |
+| 400  | Bad Request | string                |
 
 ### /invites
 
 #### GET
+
 ##### Summary:
 
 List invites
@@ -693,11 +725,12 @@ Lists all pending thread invites
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | invites | [pb.InviteViewList](#pb.inviteviewlist) |
+| Code | Description | Schema                                  |
+| ---- | ----------- | --------------------------------------- |
+| 200  | invites     | [pb.InviteViewList](#pb.inviteviewlist) |
 
 #### POST
+
 ##### Summary:
 
 Create an invite to a thread
@@ -708,22 +741,23 @@ Creates a direct account-to-account or external invite to a thread
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Opts | header | thread: Thread ID (can also use 'default'), address: Account Address (omit to create an external invite) | No | string |
+| Name           | Located in | Description                                                                                              | Required | Schema |
+| -------------- | ---------- | -------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| X-Textile-Opts | header     | thread: Thread ID (can also use 'default'), address: Account Address (omit to create an external invite) | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | invite | [pb.ExternalInvite](#pb.externalinvite) |
-| 400 | Bad Request | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                                  |
+| ---- | --------------------- | --------------------------------------- |
+| 201  | invite                | [pb.ExternalInvite](#pb.externalinvite) |
+| 400  | Bad Request           | string                                  |
+| 404  | Not Found             | string                                  |
+| 500  | Internal Server Error | string                                  |
 
 ### /invites/{id}/accept
 
 #### POST
+
 ##### Summary:
 
 Accept a thread invite
@@ -735,23 +769,24 @@ with an external invite
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | invite id | Yes | string |
-| X-Textile-Opts | header | key: key for an external invite | No | string |
+| Name           | Located in | Description                     | Required | Schema |
+| -------------- | ---------- | ------------------------------- | -------- | ------ |
+| id             | path       | invite id                       | Yes      | string |
+| X-Textile-Opts | header     | key: key for an external invite | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | join block | [pb.Block](#pb.block) |
-| 400 | Bad Request | string |
-| 409 | Conflict | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                |
+| ---- | --------------------- | --------------------- |
+| 201  | join block            | [pb.Block](#pb.block) |
+| 400  | Bad Request           | string                |
+| 409  | Conflict              | string                |
+| 500  | Internal Server Error | string                |
 
 ### /invites/{id}/ignore
 
 #### POST
+
 ##### Summary:
 
 Ignore a thread invite
@@ -763,19 +798,20 @@ Ignores a direct peer-to-peer invite to a thread
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | invite id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | invite id   | Yes      | string |
 
 ##### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | ok | string |
-| 400 | Bad Request | string |
+| 200  | ok          | string |
+| 400  | Bad Request | string |
 
 ### /ipfs/cat/{path}
 
 #### GET
+
 ##### Summary:
 
 Cat IPFS data
@@ -786,24 +822,25 @@ Displays the data behind an IPFS CID (hash) or Path
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| path | path | ipfs/ipns cid | Yes | string |
-| X-Textile-Opts | header | key: Key to decrypt data on-the-fly | No | string |
+| Name           | Located in | Description                         | Required | Schema |
+| -------------- | ---------- | ----------------------------------- | -------- | ------ |
+| path           | path       | ipfs/ipns cid                       | Yes      | string |
+| X-Textile-Opts | header     | key: Key to decrypt data on-the-fly | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | data | [ integer ] |
-| 400 | Bad Request | string |
-| 401 | Unauthorized | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema      |
+| ---- | --------------------- | ----------- |
+| 200  | data                  | [ integer ] |
+| 400  | Bad Request           | string      |
+| 401  | Unauthorized          | string      |
+| 404  | Not Found             | string      |
+| 500  | Internal Server Error | string      |
 
 ### /ipfs/id
 
 #### GET
+
 ##### Summary:
 
 Get IPFS peer ID
@@ -814,14 +851,15 @@ Displays underlying IPFS peer ID
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | peer id | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema |
+| ---- | --------------------- | ------ |
+| 200  | peer id               | string |
+| 500  | Internal Server Error | string |
 
 ### /ipfs/swarm/connect
 
 #### POST
+
 ##### Summary:
 
 Opens a new direct connection to a peer address
@@ -832,21 +870,22 @@ Opens a new direct connection to a peer using an IPFS multiaddr
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Args | header | peer address | Yes | string |
+| Name           | Located in | Description  | Required | Schema |
+| -------------- | ---------- | ------------ | -------- | ------ |
+| X-Textile-Args | header     | peer address | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | ok | [ string ] |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema     |
+| ---- | --------------------- | ---------- |
+| 200  | ok                    | [ string ] |
+| 400  | Bad Request           | string     |
+| 500  | Internal Server Error | string     |
 
 ### /ipfs/swarm/peers
 
 #### GET
+
 ##### Summary:
 
 List swarm peers
@@ -857,21 +896,22 @@ Lists the set of peers this node is connected to
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Opts | header | verbose: Display all extra information, latency: Also list information about latency to each peer, streams: Also list information about open streams for each peer, direction: Also list information about the direction of connection | No | string |
+| Name           | Located in | Description                                                                                                                                                                                                                            | Required | Schema |
+| -------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| X-Textile-Opts | header     | verbose: Display all extra information, latency: Also list information about latency to each peer, streams: Also list information about open streams for each peer, direction: Also list information about the direction of connection | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | connection | [ipfs.ConnInfos](#ipfs.conninfos) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                            |
+| ---- | --------------------- | --------------------------------- |
+| 200  | connection            | [ipfs.ConnInfos](#ipfs.conninfos) |
+| 400  | Bad Request           | string                            |
+| 500  | Internal Server Error | string                            |
 
 ### /keys/{target}
 
 #### GET
+
 ##### Summary:
 
 Show file keys
@@ -882,20 +922,21 @@ Shows file keys under the given target from an add
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| target | path | target id | Yes | string |
+| Name   | Located in | Description | Required | Schema |
+| ------ | ---------- | ----------- | -------- | ------ |
+| target | path       | target id   | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | keys | [pb.Keys](#pb.keys) |
-| 400 | Bad Request | string |
+| Code | Description | Schema              |
+| ---- | ----------- | ------------------- |
+| 200  | keys        | [pb.Keys](#pb.keys) |
+| 400  | Bad Request | string              |
 
 ### /logs/{subsystem}
 
 #### POST
+
 ##### Summary:
 
 Access subsystem logs
@@ -907,22 +948,23 @@ piggyback on the IPFS event logs
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| subsystem | path | subsystem logging identifier (omit for all) | No | string |
-| X-Textile-Opts | header | level: Log-level (one of: debug, info, warning, error, critical, or  | No | string |
+| Name           | Located in | Description                                                         | Required | Schema |
+| -------------- | ---------- | ------------------------------------------------------------------- | -------- | ------ |
+| subsystem      | path       | subsystem logging identifier (omit for all)                         | No       | string |
+| X-Textile-Opts | header     | level: Log-level (one of: debug, info, warning, error, critical, or | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | subsystems | [core.SubsystemInfo](#core.subsysteminfo) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                                    |
+| ---- | --------------------- | ----------------------------------------- |
+| 200  | subsystems            | [core.SubsystemInfo](#core.subsysteminfo) |
+| 400  | Bad Request           | string                                    |
+| 500  | Internal Server Error | string                                    |
 
 ### /messages
 
 #### GET
+
 ##### Summary:
 
 Paginates thread messages
@@ -933,22 +975,23 @@ Paginates thread messages
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Opts | header | thread: Thread ID (can also use 'default', omit for all), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5) | No | string |
+| Name           | Located in | Description                                                                                                                                             | Required | Schema |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| X-Textile-Opts | header     | thread: Thread ID (can also use 'default', omit for all), offset: Offset ID to start listing from (omit for latest), limit: List page size (default: 5) | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | messages | [pb.TextList](#pb.textlist) |
-| 400 | Bad Request | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                      |
+| ---- | --------------------- | --------------------------- |
+| 200  | messages              | [pb.TextList](#pb.textlist) |
+| 400  | Bad Request           | string                      |
+| 404  | Not Found             | string                      |
+| 500  | Internal Server Error | string                      |
 
 ### /messages/{block}
 
 #### GET
+
 ##### Summary:
 
 Get thread message
@@ -959,20 +1002,21 @@ Gets a thread message by block ID
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| block | path | block id | Yes | string |
+| Name  | Located in | Description | Required | Schema |
+| ----- | ---------- | ----------- | -------- | ------ |
+| block | path       | block id    | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | message | [pb.Text](#pb.text) |
-| 400 | Bad Request | string |
+| Code | Description | Schema              |
+| ---- | ----------- | ------------------- |
+| 200  | message     | [pb.Text](#pb.text) |
+| 400  | Bad Request | string              |
 
 ### /mills/blob
 
 #### POST
+
 ##### Summary:
 
 Process raw data blobs
@@ -984,22 +1028,23 @@ and returns a file object
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| file | formData | multipart/form-data file | No | file |
-| X-Textile-Opts | header | plaintext: whether to leave unencrypted), use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS | No | string |
+| Name           | Located in | Description                                                                                                                                                   | Required | Schema |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| file           | formData   | multipart/form-data file                                                                                                                                      | No       | file   |
+| X-Textile-Opts | header     | plaintext: whether to leave unencrypted), use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | file | [pb.FileIndex](#pb.fileindex) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                        |
+| ---- | --------------------- | ----------------------------- |
+| 201  | file                  | [pb.FileIndex](#pb.fileindex) |
+| 400  | Bad Request           | string                        |
+| 500  | Internal Server Error | string                        |
 
 ### /mills/image/exif
 
 #### POST
+
 ##### Summary:
 
 Extract EXIF data from image
@@ -1011,22 +1056,23 @@ before adding to IPFS, and returns a file object
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| file | formData | multipart/form-data file | No | file |
-| X-Textile-Opts | header | plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS | No | string |
+| Name           | Located in | Description                                                                                                                                                  | Required | Schema |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------ |
+| file           | formData   | multipart/form-data file                                                                                                                                     | No       | file   |
+| X-Textile-Opts | header     | plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | file | [pb.FileIndex](#pb.fileindex) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                        |
+| ---- | --------------------- | ----------------------------- |
+| 201  | file                  | [pb.FileIndex](#pb.fileindex) |
+| 400  | Bad Request           | string                        |
+| 500  | Internal Server Error | string                        |
 
 ### /mills/image/resize
 
 #### POST
+
 ##### Summary:
 
 Resize an image
@@ -1038,22 +1084,23 @@ before adding to IPFS, and returns a file object
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| file | formData | multipart/form-data file | No | file |
-| X-Textile-Opts | header | plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS, width: the requested image width (required), quality: the requested JPEG image quality | Yes | string |
+| Name           | Located in | Description                                                                                                                                                                                                                                          | Required | Schema |
+| -------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| file           | formData   | multipart/form-data file                                                                                                                                                                                                                             | No       | file   |
+| X-Textile-Opts | header     | plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS, width: the requested image width (required), quality: the requested JPEG image quality | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | file | [pb.FileIndex](#pb.fileindex) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                        |
+| ---- | --------------------- | ----------------------------- |
+| 201  | file                  | [pb.FileIndex](#pb.fileindex) |
+| 400  | Bad Request           | string                        |
+| 500  | Internal Server Error | string                        |
 
 ### /mills/json
 
 #### POST
+
 ##### Summary:
 
 Process input JSON data
@@ -1065,22 +1112,23 @@ optionally encrypts the output before adding to IPFS, and returns a file object
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| file | formData | multipart/form-data file | No | file |
-| X-Textile-Opts | header | plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS | No | string |
+| Name           | Located in | Description                                                                                                                                                  | Required | Schema |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------ |
+| file           | formData   | multipart/form-data file                                                                                                                                     | No       | file   |
+| X-Textile-Opts | header     | plaintext: whether to leave unencrypted, use: if empty, assumes body contains multipart form file data, otherwise, will attempt to fetch given CID from IPFS | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | file | [pb.FileIndex](#pb.fileindex) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                        |
+| ---- | --------------------- | ----------------------------- |
+| 201  | file                  | [pb.FileIndex](#pb.fileindex) |
+| 400  | Bad Request           | string                        |
+| 500  | Internal Server Error | string                        |
 
 ### /mills/schema
 
 #### POST
+
 ##### Summary:
 
 Validate, add, and pin a new Schema
@@ -1091,20 +1139,21 @@ Takes a JSON-based Schema, validates it, adds it to IPFS, and returns a file obj
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| schema | body | schema | Yes | [pb.Node](#pb.node) |
+| Name   | Located in | Description | Required | Schema              |
+| ------ | ---------- | ----------- | -------- | ------------------- |
+| schema | body       | schema      | Yes      | [pb.Node](#pb.node) |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | file | [pb.FileIndex](#pb.fileindex) |
-| 400 | Bad Request | string |
+| Code | Description | Schema                        |
+| ---- | ----------- | ----------------------------- |
+| 201  | file        | [pb.FileIndex](#pb.fileindex) |
+| 400  | Bad Request | string                        |
 
 ### /notifications
 
 #### GET
+
 ##### Summary:
 
 List notifications
@@ -1115,13 +1164,14 @@ Lists all notifications generated by thread and account activity.
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | notifications | [pb.NotificationList](#pb.notificationlist) |
+| Code | Description   | Schema                                      |
+| ---- | ------------- | ------------------------------------------- |
+| 200  | notifications | [pb.NotificationList](#pb.notificationlist) |
 
 ### /notifications/{id}/read
 
 #### POST
+
 ##### Summary:
 
 Mark notifiction as read
@@ -1132,20 +1182,21 @@ Marks a notifiction as read by ID. Use 'all' to mark all as read.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | notification id | Yes | string |
+| Name | Located in | Description     | Required | Schema |
+| ---- | ---------- | --------------- | -------- | ------ |
+| id   | path       | notification id | Yes      | string |
 
 ##### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | ok | string |
-| 400 | Bad Request | string |
+| 200  | ok          | string |
+| 400  | Bad Request | string |
 
 ### /ping
 
 #### GET
+
 ##### Summary:
 
 Ping a network peer
@@ -1156,21 +1207,22 @@ Pings another peer on the network, returning online|offline.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Args | header | peerid | Yes | string |
+| Name           | Located in | Description | Required | Schema |
+| -------------- | ---------- | ----------- | -------- | ------ |
+| X-Textile-Args | header     | peerid      | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | One of online|offline | string |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema  |
+| ---- | --------------------- | ------- |
+| 200  | One of online         | offline | string |
+| 400  | Bad Request           | string  |
+| 500  | Internal Server Error | string  |
 
 ### /profile
 
 #### GET
+
 ##### Summary:
 
 Get public profile
@@ -1181,14 +1233,15 @@ Gets the local node's public profile
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | peer | [pb.Peer](#pb.peer) |
-| 400 | Bad Request | string |
+| Code | Description | Schema              |
+| ---- | ----------- | ------------------- |
+| 200  | peer        | [pb.Peer](#pb.peer) |
+| 400  | Bad Request | string              |
 
 ### /profile/avatar
 
 #### POST
+
 ##### Summary:
 
 Set avatar
@@ -1199,21 +1252,22 @@ Sets public profile avatar by specifying an existing image file hash
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Args | header | hash | Yes | string |
+| Name           | Located in | Description | Required | Schema |
+| -------------- | ---------- | ----------- | -------- | ------ |
+| X-Textile-Args | header     | hash        | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | ok | string |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema |
+| ---- | --------------------- | ------ |
+| 201  | ok                    | string |
+| 400  | Bad Request           | string |
+| 500  | Internal Server Error | string |
 
 ### /profile/name
 
 #### POST
+
 ##### Summary:
 
 Set display name
@@ -1224,21 +1278,22 @@ Sets public profile display name to given string
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Args | header | name | Yes | string |
+| Name           | Located in | Description | Required | Schema |
+| -------------- | ---------- | ----------- | -------- | ------ |
+| X-Textile-Args | header     | name        | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | ok | string |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema |
+| ---- | --------------------- | ------ |
+| 201  | ok                    | string |
+| 400  | Bad Request           | string |
+| 500  | Internal Server Error | string |
 
 ### /snapshots
 
 #### POST
+
 ##### Summary:
 
 Create thread snapshots
@@ -1249,15 +1304,16 @@ Snapshots all threads and pushes to registered cafes
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | ok | string |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema |
+| ---- | --------------------- | ------ |
+| 201  | ok                    | string |
+| 400  | Bad Request           | string |
+| 500  | Internal Server Error | string |
 
 ### /snapshots/search
 
 #### POST
+
 ##### Summary:
 
 Search for thread snapshots
@@ -1268,21 +1324,22 @@ Searches the network for thread snapshots
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Opts | header | wait: Stops searching after 'wait' seconds have elapsed (max 30s), events: Whether to emit Server-Sent Events (SSEvent) or plain JSON | No | string |
+| Name           | Located in | Description                                                                                                                           | Required | Schema |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| X-Textile-Opts | header     | wait: Stops searching after 'wait' seconds have elapsed (max 30s), events: Whether to emit Server-Sent Events (SSEvent) or plain JSON | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | results stream | [pb.QueryResult](#pb.queryresult) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                            |
+| ---- | --------------------- | --------------------------------- |
+| 200  | results stream        | [pb.QueryResult](#pb.queryresult) |
+| 400  | Bad Request           | string                            |
+| 500  | Internal Server Error | string                            |
 
 ### /subscribe/{id}
 
 #### GET
+
 ##### Summary:
 
 Subscribe to thread updates
@@ -1295,34 +1352,36 @@ MERGE, IGNORE, FLAG, JOIN, ANNOUNCE, LEAVE, TEXT, FILES, COMMENT, LIKE
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | thread id, omit to stream all events | No | string |
-| X-Textile-Opts | header | type: Or'd list of event types (e.g., FILES|COMMENTS|LIKES) or empty to include all types, events: Whether to emit Server-Sent Events (SSEvent) or plain JSON | No | string |
+| Name           | Located in | Description                                 | Required | Schema                                                                                                   |
+| -------------- | ---------- | ------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| id             | path       | thread id, omit to stream all events        | No       | string                                                                                                   |
+| X-Textile-Opts | header     | type: Or'd list of event types (e.g., FILES | COMMENTS | LIKES) or empty to include all types, events: Whether to emit Server-Sent Events (SSEvent) or plain JSON | No | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | stream of updates | [pb.FeedItem](#pb.feeditem) |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                      |
+| ---- | --------------------- | --------------------------- |
+| 200  | stream of updates     | [pb.FeedItem](#pb.feeditem) |
+| 500  | Internal Server Error | string                      |
 
 ### /summary
 
 #### GET
+
 ##### Summary:
 
 Get a summary of node data
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | summary | [pb.Summary](#pb.summary) |
+| Code | Description | Schema                    |
+| ---- | ----------- | ------------------------- |
+| 200  | summary     | [pb.Summary](#pb.summary) |
 
 ### /threads
 
 #### GET
+
 ##### Summary:
 
 Lists info on all threads
@@ -1333,13 +1392,14 @@ Lists all local threads, returning a ThreadList object
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | threads | [pb.ThreadList](#pb.threadlist) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                          |
+| ---- | --------------------- | ------------------------------- |
+| 200  | threads               | [pb.ThreadList](#pb.threadlist) |
+| 400  | Bad Request           | string                          |
+| 500  | Internal Server Error | string                          |
 
 #### POST
+
 ##### Summary:
 
 Adds and joins a new thread
@@ -1351,22 +1411,23 @@ a Thread object
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Args | header | name | Yes | string |
-| X-Textile-Opts | header | key: A locally unique key used by an app to identify this thread on recovery, schema: Existing Thread Schema IPFS CID, type: Set the thread type to one of 'private', 'read_only', 'public', or 'open', sharing: Set the thread sharing style to one of 'not_shared','invite_only', or 'shared', whitelist: An array of contact addresses. When supplied, the thread will not allow additional peers beyond those in array, useful for 1-1 chat/file sharing | No | string |
+| Name           | Located in | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Required | Schema |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------ |
+| X-Textile-Args | header     | name                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Yes      | string |
+| X-Textile-Opts | header     | key: A locally unique key used by an app to identify this thread on recovery, schema: Existing Thread Schema IPFS CID, type: Set the thread type to one of 'private', 'read_only', 'public', or 'open', sharing: Set the thread sharing style to one of 'not_shared','invite_only', or 'shared', whitelist: An array of contact addresses. When supplied, the thread will not allow additional peers beyond those in array, useful for 1-1 chat/file sharing | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | thread | [pb.Thread](#pb.thread) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                  |
+| ---- | --------------------- | ----------------------- |
+| 201  | thread                | [pb.Thread](#pb.thread) |
+| 400  | Bad Request           | string                  |
+| 500  | Internal Server Error | string                  |
 
 ### /threads/{id}
 
 #### DELETE
+
 ##### Summary:
 
 Leave and remove a thread
@@ -1378,18 +1439,19 @@ Leaves and removes a thread
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | thread id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | thread id   | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 204 | ok | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema |
+| ---- | --------------------- | ------ |
+| 204  | ok                    | string |
+| 404  | Not Found             | string |
+| 500  | Internal Server Error | string |
 
 #### GET
+
 ##### Summary:
 
 Gets a thread
@@ -1401,18 +1463,19 @@ Gets and displays info about a thread
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | thread id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | thread id   | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | thread | [pb.Thread](#pb.thread) |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                  |
+| ---- | --------------------- | ----------------------- |
+| 200  | thread                | [pb.Thread](#pb.thread) |
+| 400  | Bad Request           | string                  |
+| 500  | Internal Server Error | string                  |
 
 #### PUT
+
 ##### Summary:
 
 Add or update a thread directly
@@ -1423,21 +1486,22 @@ Adds or updates a thread directly, usually from a backup
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | id | Yes | string |
-| thread | body | thread | Yes | [pb.Thread](#pb.thread) |
+| Name   | Located in | Description | Required | Schema                  |
+| ------ | ---------- | ----------- | -------- | ----------------------- |
+| id     | path       | id          | Yes      | string                  |
+| thread | body       | thread      | Yes      | [pb.Thread](#pb.thread) |
 
 ##### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 204 | ok | string |
-| 400 | Bad Request | string |
+| 204  | ok          | string |
+| 400  | Bad Request | string |
 
 ### /threads/{id}/files
 
 #### POST
+
 ##### Summary:
 
 Adds a file or directory of files to a thread
@@ -1450,23 +1514,24 @@ also be used as input.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| dir | body | list of milled dirs (output from mill endpoint) | Yes | [pb.DirectoryList](#pb.directorylist) |
-| X-Textile-Opts | header | caption: Caption to add to file(s) | No | string |
+| Name           | Located in | Description                                     | Required | Schema                                |
+| -------------- | ---------- | ----------------------------------------------- | -------- | ------------------------------------- |
+| dir            | body       | list of milled dirs (output from mill endpoint) | Yes      | [pb.DirectoryList](#pb.directorylist) |
+| X-Textile-Opts | header     | caption: Caption to add to file(s)              | No       | string                                |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | file | [pb.Files](#pb.files) |
-| 400 | Bad Request | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema                |
+| ---- | --------------------- | --------------------- |
+| 201  | file                  | [pb.Files](#pb.files) |
+| 400  | Bad Request           | string                |
+| 404  | Not Found             | string                |
+| 500  | Internal Server Error | string                |
 
 ### /threads/{id}/messages
 
 #### POST
+
 ##### Summary:
 
 Add a message
@@ -1477,22 +1542,23 @@ Adds a message to a thread
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Args | header | urlescaped message body | Yes | string |
+| Name           | Located in | Description             | Required | Schema |
+| -------------- | ---------- | ----------------------- | -------- | ------ |
+| X-Textile-Args | header     | urlescaped message body | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | message | [pb.Text](#pb.text) |
-| 400 | Bad Request | string |
-| 404 | Not Found | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema              |
+| ---- | --------------------- | ------------------- |
+| 200  | message               | [pb.Text](#pb.text) |
+| 400  | Bad Request           | string              |
+| 404  | Not Found             | string              |
+| 500  | Internal Server Error | string              |
 
 ### /threads/{id}/name
 
 #### PUT
+
 ##### Summary:
 
 Rename a thread
@@ -1503,21 +1569,22 @@ Renames a thread. Only initiators can rename a thread.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | id | Yes | string |
-| X-Textile-Args | header | name | Yes | string |
+| Name           | Located in | Description | Required | Schema |
+| -------------- | ---------- | ----------- | -------- | ------ |
+| id             | path       | id          | Yes      | string |
+| X-Textile-Args | header     | name        | Yes      | string |
 
 ##### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 204 | ok | string |
-| 400 | Bad Request | string |
+| 204  | ok          | string |
+| 400  | Bad Request | string |
 
 ### /threads/{id}/peers
 
 #### GET
+
 ##### Summary:
 
 List all thread peers
@@ -1529,19 +1596,20 @@ Lists all peers in a thread, optionally listing peers in the default thread
 ##### Parameters
 
 | Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| id | path | thread id | Yes | string |
+| ---- | ---------- | ----------- | -------- | ------ |
+| id   | path       | thread id   | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | contacts | [pb.ContactList](#pb.contactlist) |
-| 404 | Not Found | string |
+| Code | Description | Schema                            |
+| ---- | ----------- | --------------------------------- |
+| 200  | contacts    | [pb.ContactList](#pb.contactlist) |
+| 404  | Not Found   | string                            |
 
 ### /tokens
 
 #### GET
+
 ##### Summary:
 
 List local tokens
@@ -1552,12 +1620,13 @@ List info about all stored cafe tokens
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | tokens | [ string ] |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema     |
+| ---- | --------------------- | ---------- |
+| 200  | tokens                | [ string ] |
+| 500  | Internal Server Error | string     |
 
 #### POST
+
 ##### Summary:
 
 Create an access token
@@ -1573,21 +1642,22 @@ Tokens allow other peers to register with a Cafe peer.
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| X-Textile-Opts | header | token: Use existing token, rather than creating a new one, store: Whether to store the added/generated token to the local db | No | string |
+| Name           | Located in | Description                                                                                                                  | Required | Schema |
+| -------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| X-Textile-Opts | header     | token: Use existing token, rather than creating a new one, store: Whether to store the added/generated token to the local db | No       | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 201 | token | string |
-| 400 | Bad Request | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema |
+| ---- | --------------------- | ------ |
+| 201  | token                 | string |
+| 400  | Bad Request           | string |
+| 500  | Internal Server Error | string |
 
 ### /tokens/{id}
 
 #### DELETE
+
 ##### Summary:
 
 Removes a cafe token
@@ -1598,18 +1668,19 @@ Removes an existing cafe token
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| token | path | token | Yes | string |
+| Name  | Located in | Description | Required | Schema |
+| ----- | ---------- | ----------- | -------- | ------ |
+| token | path       | token       | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 204 | ok | string |
-| 500 | Internal Server Error | string |
+| Code | Description           | Schema |
+| ---- | --------------------- | ------ |
+| 204  | ok                    | string |
+| 500  | Internal Server Error | string |
 
 #### GET
+
 ##### Summary:
 
 Check token validity
@@ -1620,368 +1691,367 @@ Check validity of existing cafe access token
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| token | path | invite id | Yes | string |
+| Name  | Located in | Description | Required | Schema |
+| ----- | ---------- | ----------- | -------- | ------ |
+| token | path       | invite id   | Yes      | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | ok | string |
-| 401 | Unauthorized | string |
+| Code | Description  | Schema |
+| ---- | ------------ | ------ |
+| 200  | ok           | string |
+| 401  | Unauthorized | string |
 
 ### Models
 
-
 #### core.SubsystemInfo
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| core.SubsystemInfo | object |  |  |
+| Name               | Type   | Description | Required |
+| ------------------ | ------ | ----------- | -------- |
+| core.SubsystemInfo | object |             |          |
 
 #### ipfs.ConnInfos
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| peers | [ [ipfs.connInfo](#ipfs.conninfo) ] |  | No |
+| Name  | Type                                | Description | Required |
+| ----- | ----------------------------------- | ----------- | -------- |
+| peers | [ [ipfs.connInfo](#ipfs.conninfo) ] |             | No       |
 
 #### ipfs.connInfo
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| addr | string |  | No |
-| direction | string |  | No |
-| latency | string |  | No |
-| muxer | string |  | No |
-| peer | string |  | No |
-| streams | [ [ipfs.streamInfo](#ipfs.streaminfo) ] |  | No |
+| Name      | Type                                    | Description | Required |
+| --------- | --------------------------------------- | ----------- | -------- |
+| addr      | string                                  |             | No       |
+| direction | string                                  |             | No       |
+| latency   | string                                  |             | No       |
+| muxer     | string                                  |             | No       |
+| peer      | string                                  |             | No       |
+| streams   | [ [ipfs.streamInfo](#ipfs.streaminfo) ] |             | No       |
 
 #### ipfs.streamInfo
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| protocol | string |  | No |
+| Name     | Type   | Description | Required |
+| -------- | ------ | ----------- | -------- |
+| protocol | string |             | No       |
 
 #### mill.Json
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| mill.Json | object |  |  |
+| Name      | Type   | Description | Required |
+| --------- | ------ | ----------- | -------- |
+| mill.Json | object |             |          |
 
 #### pb.Block
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| author | string |  | No |
-| body | string |  | No |
-| date | string |  | No |
-| id | string |  | No |
-| parents | [ string ] |  | No |
-| target | string |  | No |
-| thread | string |  | No |
-| type | integer |  | No |
-| user | [pb.User](#pb.user) | view info | No |
+| Name    | Type                | Description | Required |
+| ------- | ------------------- | ----------- | -------- |
+| author  | string              |             | No       |
+| body    | string              |             | No       |
+| date    | string              |             | No       |
+| id      | string              |             | No       |
+| parents | [ string ]          |             | No       |
+| target  | string              |             | No       |
+| thread  | string              |             | No       |
+| type    | integer             |             | No       |
+| user    | [pb.User](#pb.user) | view info   | No       |
 
 #### pb.BlockList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.Block](#pb.block) ] |  | No |
+| Name  | Type                      | Description | Required |
+| ----- | ------------------------- | ----------- | -------- |
+| items | [ [pb.Block](#pb.block) ] |             | No       |
 
 #### pb.Cafe
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| address | string |  | No |
-| api | string |  | No |
-| node | string |  | No |
-| peer | string |  | No |
-| protocol | string |  | No |
-| swarm | [ string ] |  | No |
-| url | string |  | No |
+| Name     | Type       | Description | Required |
+| -------- | ---------- | ----------- | -------- |
+| address  | string     |             | No       |
+| api      | string     |             | No       |
+| node     | string     |             | No       |
+| peer     | string     |             | No       |
+| protocol | string     |             | No       |
+| swarm    | [ string ] |             | No       |
+| url      | string     |             | No       |
 
 #### pb.CafeSession
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| access | string |  | No |
-| cafe | [pb.Cafe](#pb.cafe) |  | No |
-| exp | string |  | No |
-| id | string |  | No |
-| refresh | string |  | No |
-| rexp | string |  | No |
-| subject | string |  | No |
-| type | string |  | No |
+| Name    | Type                | Description | Required |
+| ------- | ------------------- | ----------- | -------- |
+| access  | string              |             | No       |
+| cafe    | [pb.Cafe](#pb.cafe) |             | No       |
+| exp     | string              |             | No       |
+| id      | string              |             | No       |
+| refresh | string              |             | No       |
+| rexp    | string              |             | No       |
+| subject | string              |             | No       |
+| type    | string              |             | No       |
 
 #### pb.CafeSessionList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.CafeSession](#pb.cafesession) ] |  | No |
+| Name  | Type                                  | Description | Required |
+| ----- | ------------------------------------- | ----------- | -------- |
+| items | [ [pb.CafeSession](#pb.cafesession) ] |             | No       |
 
 #### pb.Comment
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| body | string |  | No |
-| date | string |  | No |
-| id | string |  | No |
-| target | [pb.FeedItem](#pb.feeditem) |  | No |
-| user | [pb.User](#pb.user) |  | No |
+| Name   | Type                        | Description | Required |
+| ------ | --------------------------- | ----------- | -------- |
+| body   | string                      |             | No       |
+| date   | string                      |             | No       |
+| id     | string                      |             | No       |
+| target | [pb.FeedItem](#pb.feeditem) |             | No       |
+| user   | [pb.User](#pb.user)         |             | No       |
 
 #### pb.CommentList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.Comment](#pb.comment) ] |  | No |
+| Name  | Type                          | Description | Required |
+| ----- | ----------------------------- | ----------- | -------- |
+| items | [ [pb.Comment](#pb.comment) ] |             | No       |
 
 #### pb.Contact
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| address | string |  | No |
-| avatar | string |  | No |
-| name | string |  | No |
-| peers | [ [pb.Peer](#pb.peer) ] |  | No |
-| threads | [ string ] |  | No |
+| Name    | Type                    | Description | Required |
+| ------- | ----------------------- | ----------- | -------- |
+| address | string                  |             | No       |
+| avatar  | string                  |             | No       |
+| name    | string                  |             | No       |
+| peers   | [ [pb.Peer](#pb.peer) ] |             | No       |
+| threads | [ string ]              |             | No       |
 
 #### pb.ContactList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.Contact](#pb.contact) ] |  | No |
+| Name  | Type                          | Description | Required |
+| ----- | ----------------------------- | ----------- | -------- |
+| items | [ [pb.Contact](#pb.contact) ] |             | No       |
 
 #### pb.Directory
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| files | object |  | No |
+| Name  | Type   | Description | Required |
+| ----- | ------ | ----------- | -------- |
+| files | object |             | No       |
 
 #### pb.DirectoryList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.Directory](#pb.directory) ] |  | No |
+| Name  | Type                              | Description | Required |
+| ----- | --------------------------------- | ----------- | -------- |
+| items | [ [pb.Directory](#pb.directory) ] |             | No       |
 
 #### pb.ExternalInvite
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| id | string |  | No |
-| inviter | string |  | No |
-| key | string |  | No |
+| Name    | Type   | Description | Required |
+| ------- | ------ | ----------- | -------- |
+| id      | string |             | No       |
+| inviter | string |             | No       |
+| key     | string |             | No       |
 
 #### pb.FeedItem
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| block | string |  | No |
-| payload | string |  | No |
-| thread | string |  | No |
+| Name    | Type   | Description | Required |
+| ------- | ------ | ----------- | -------- |
+| block   | string |             | No       |
+| payload | string |             | No       |
+| thread  | string |             | No       |
 
 #### pb.FeedItemList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| count | integer |  | No |
-| items | [ [pb.FeedItem](#pb.feeditem) ] |  | No |
-| next | string |  | No |
+| Name  | Type                            | Description | Required |
+| ----- | ------------------------------- | ----------- | -------- |
+| count | integer                         |             | No       |
+| items | [ [pb.FeedItem](#pb.feeditem) ] |             | No       |
+| next  | string                          |             | No       |
 
 #### pb.File
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| file | [pb.FileIndex](#pb.fileindex) |  | No |
-| index | integer |  | No |
-| links | object |  | No |
+| Name  | Type                          | Description | Required |
+| ----- | ----------------------------- | ----------- | -------- |
+| file  | [pb.FileIndex](#pb.fileindex) |             | No       |
+| index | integer                       |             | No       |
+| links | object                        |             | No       |
 
 #### pb.FileIndex
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| added | string |  | No |
-| checksum | string |  | No |
-| hash | string |  | No |
-| key | string |  | No |
-| media | string |  | No |
-| meta | string |  | No |
-| mill | string |  | No |
-| name | string |  | No |
-| opts | string |  | No |
-| size | integer |  | No |
-| source | string |  | No |
-| targets | [ string ] |  | No |
+| Name     | Type       | Description | Required |
+| -------- | ---------- | ----------- | -------- |
+| added    | string     |             | No       |
+| checksum | string     |             | No       |
+| hash     | string     |             | No       |
+| key      | string     |             | No       |
+| media    | string     |             | No       |
+| meta     | string     |             | No       |
+| mill     | string     |             | No       |
+| name     | string     |             | No       |
+| opts     | string     |             | No       |
+| size     | integer    |             | No       |
+| source   | string     |             | No       |
+| targets  | [ string ] |             | No       |
 
 #### pb.Files
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| block | string |  | No |
-| caption | string |  | No |
-| comments | [ [pb.Comment](#pb.comment) ] |  | No |
-| date | string |  | No |
-| files | [ [pb.File](#pb.file) ] |  | No |
-| likes | [ [pb.Like](#pb.like) ] |  | No |
-| target | string |  | No |
-| threads | [ string ] |  | No |
-| user | [pb.User](#pb.user) |  | No |
+| Name     | Type                          | Description | Required |
+| -------- | ----------------------------- | ----------- | -------- |
+| block    | string                        |             | No       |
+| caption  | string                        |             | No       |
+| comments | [ [pb.Comment](#pb.comment) ] |             | No       |
+| date     | string                        |             | No       |
+| files    | [ [pb.File](#pb.file) ]       |             | No       |
+| likes    | [ [pb.Like](#pb.like) ]       |             | No       |
+| target   | string                        |             | No       |
+| threads  | [ string ]                    |             | No       |
+| user     | [pb.User](#pb.user)           |             | No       |
 
 #### pb.FilesList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.Files](#pb.files) ] |  | No |
+| Name  | Type                      | Description | Required |
+| ----- | ------------------------- | ----------- | -------- |
+| items | [ [pb.Files](#pb.files) ] |             | No       |
 
 #### pb.InviteView
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| date | string |  | No |
-| id | string |  | No |
-| inviter | [pb.User](#pb.user) |  | No |
-| name | string |  | No |
+| Name    | Type                | Description | Required |
+| ------- | ------------------- | ----------- | -------- |
+| date    | string              |             | No       |
+| id      | string              |             | No       |
+| inviter | [pb.User](#pb.user) |             | No       |
+| name    | string              |             | No       |
 
 #### pb.InviteViewList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.InviteView](#pb.inviteview) ] |  | No |
+| Name  | Type                                | Description | Required |
+| ----- | ----------------------------------- | ----------- | -------- |
+| items | [ [pb.InviteView](#pb.inviteview) ] |             | No       |
 
 #### pb.Keys
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| files | object |  | No |
+| Name  | Type   | Description | Required |
+| ----- | ------ | ----------- | -------- |
+| files | object |             | No       |
 
 #### pb.Like
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| date | string |  | No |
-| id | string |  | No |
-| target | [pb.FeedItem](#pb.feeditem) |  | No |
-| user | [pb.User](#pb.user) |  | No |
+| Name   | Type                        | Description | Required |
+| ------ | --------------------------- | ----------- | -------- |
+| date   | string                      |             | No       |
+| id     | string                      |             | No       |
+| target | [pb.FeedItem](#pb.feeditem) |             | No       |
+| user   | [pb.User](#pb.user)         |             | No       |
 
 #### pb.LikeList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.Like](#pb.like) ] |  | No |
+| Name  | Type                    | Description | Required |
+| ----- | ----------------------- | ----------- | -------- |
+| items | [ [pb.Like](#pb.like) ] |             | No       |
 
 #### pb.Node
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| json_schema | string |  | No |
-| links | object |  | No |
-| mill | string |  | No |
-| name | string |  | No |
-| opts | object |  | No |
-| pin | boolean |  | No |
-| plaintext | boolean |  | No |
+| Name        | Type    | Description | Required |
+| ----------- | ------- | ----------- | -------- |
+| json_schema | string  |             | No       |
+| links       | object  |             | No       |
+| mill        | string  |             | No       |
+| name        | string  |             | No       |
+| opts        | object  |             | No       |
+| pin         | boolean |             | No       |
+| plaintext   | boolean |             | No       |
 
 #### pb.Notification
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| actor | string |  | No |
-| block | string |  | No |
-| body | string |  | No |
-| date | string |  | No |
-| id | string |  | No |
-| read | boolean |  | No |
-| subject | string |  | No |
-| subject_desc | string |  | No |
-| target | string |  | No |
-| type | integer |  | No |
-| user | [pb.User](#pb.user) | view info | No |
+| Name         | Type                | Description | Required |
+| ------------ | ------------------- | ----------- | -------- |
+| actor        | string              |             | No       |
+| block        | string              |             | No       |
+| body         | string              |             | No       |
+| date         | string              |             | No       |
+| id           | string              |             | No       |
+| read         | boolean             |             | No       |
+| subject      | string              |             | No       |
+| subject_desc | string              |             | No       |
+| target       | string              |             | No       |
+| type         | integer             |             | No       |
+| user         | [pb.User](#pb.user) | view info   | No       |
 
 #### pb.NotificationList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.Notification](#pb.notification) ] |  | No |
+| Name  | Type                                    | Description | Required |
+| ----- | --------------------------------------- | ----------- | -------- |
+| items | [ [pb.Notification](#pb.notification) ] |             | No       |
 
 #### pb.Peer
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| address | string |  | No |
-| avatar | string |  | No |
-| created | string |  | No |
-| id | string |  | No |
-| inboxes | [ [pb.Cafe](#pb.cafe) ] |  | No |
-| name | string |  | No |
-| updated | string |  | No |
+| Name    | Type                    | Description | Required |
+| ------- | ----------------------- | ----------- | -------- |
+| address | string                  |             | No       |
+| avatar  | string                  |             | No       |
+| created | string                  |             | No       |
+| id      | string                  |             | No       |
+| inboxes | [ [pb.Cafe](#pb.cafe) ] |             | No       |
+| name    | string                  |             | No       |
+| updated | string                  |             | No       |
 
 #### pb.QueryResult
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| date | string |  | No |
-| id | string |  | No |
-| local | boolean |  | No |
-| value | string |  | No |
+| Name  | Type    | Description | Required |
+| ----- | ------- | ----------- | -------- |
+| date  | string  |             | No       |
+| id    | string  |             | No       |
+| local | boolean |             | No       |
+| value | string  |             | No       |
 
 #### pb.Summary
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| account_peer_count | integer |  | No |
-| address | string |  | No |
-| contact_count | integer |  | No |
-| files_count | integer |  | No |
-| id | string |  | No |
-| thread_count | integer |  | No |
+| Name               | Type    | Description | Required |
+| ------------------ | ------- | ----------- | -------- |
+| account_peer_count | integer |             | No       |
+| address            | string  |             | No       |
+| contact_count      | integer |             | No       |
+| files_count        | integer |             | No       |
+| id                 | string  |             | No       |
+| thread_count       | integer |             | No       |
 
 #### pb.Text
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| block | string |  | No |
-| body | string |  | No |
-| comments | [ [pb.Comment](#pb.comment) ] |  | No |
-| date | string |  | No |
-| likes | [ [pb.Like](#pb.like) ] |  | No |
-| user | [pb.User](#pb.user) |  | No |
+| Name     | Type                          | Description | Required |
+| -------- | ----------------------------- | ----------- | -------- |
+| block    | string                        |             | No       |
+| body     | string                        |             | No       |
+| comments | [ [pb.Comment](#pb.comment) ] |             | No       |
+| date     | string                        |             | No       |
+| likes    | [ [pb.Like](#pb.like) ]       |             | No       |
+| user     | [pb.User](#pb.user)           |             | No       |
 
 #### pb.TextList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.Text](#pb.text) ] |  | No |
+| Name  | Type                    | Description | Required |
+| ----- | ----------------------- | ----------- | -------- |
+| items | [ [pb.Text](#pb.text) ] |             | No       |
 
 #### pb.Thread
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| block_count | integer |  | No |
-| head | string |  | No |
-| head_block | [pb.Block](#pb.block) | view info | No |
-| id | string |  | No |
-| initiator | string |  | No |
-| key | string |  | No |
-| name | string |  | No |
-| peer_count | integer |  | No |
-| schema | string |  | No |
-| schema_node | [pb.Node](#pb.node) |  | No |
-| sharing | integer |  | No |
-| sk | [ integer ] |  | No |
-| state | integer |  | No |
-| type | integer |  | No |
-| whitelist | [ string ] |  | No |
+| Name        | Type                  | Description | Required |
+| ----------- | --------------------- | ----------- | -------- |
+| block_count | integer               |             | No       |
+| head        | string                |             | No       |
+| head_block  | [pb.Block](#pb.block) | view info   | No       |
+| id          | string                |             | No       |
+| initiator   | string                |             | No       |
+| key         | string                |             | No       |
+| name        | string                |             | No       |
+| peer_count  | integer               |             | No       |
+| schema      | string                |             | No       |
+| schema_node | [pb.Node](#pb.node)   |             | No       |
+| sharing     | integer               |             | No       |
+| sk          | [ integer ]           |             | No       |
+| state       | integer               |             | No       |
+| type        | integer               |             | No       |
+| whitelist   | [ string ]            |             | No       |
 
 #### pb.ThreadList
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [pb.Thread](#pb.thread) ] |  | No |
+| Name  | Type                        | Description | Required |
+| ----- | --------------------------- | ----------- | -------- |
+| items | [ [pb.Thread](#pb.thread) ] |             | No       |
 
 #### pb.User
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| address | string |  | No |
-| avatar | string |  | No |
-| name | string |  | No |
+| Name    | Type   | Description | Required |
+| ------- | ------ | ----------- | -------- |
+| address | string |             | No       |
+| avatar  | string |             | No       |
+| name    | string |             | No       |

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -510,52 +510,52 @@ info:
     url: https://github.com/textileio/go-textile/blob/master/LICENSE
   termsOfService: https://github.com/textileio/go-textile/blob/master/TERMS
   title: Textile REST API
-  version: "0"
+  version: '0'
 paths:
   /account:
     get:
       description: Shows the local peer's account info as a contact
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: contact
           schema:
             $ref: '#/definitions/pb.Contact'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Show account contact
       tags:
-      - account
+        - account
   /account/address:
     get:
       description: Shows the local peer's account address
       produces:
-      - text/plain
+        - text/plain
       responses:
-        "200":
+        '200':
           description: address
           schema:
             type: string
       summary: Show account address
       tags:
-      - account
+        - account
   /account/seed:
     get:
       description: Shows the local peer's account seed
       produces:
-      - text/plain
+        - text/plain
       responses:
-        "200":
+        '200':
           description: seed
           schema:
             type: string
       summary: Show account seed
       tags:
-      - account
+        - account
   /blocks:
     get:
       description: |-
@@ -564,383 +564,385 @@ paths:
         hash-linked to its parent(s). New / recovering peers can sync history by simply
         traversing the hash tree.
       parameters:
-      - default: thread=,offset=,limit=5
-        description: 'thread: Thread ID (can also use ''default''), offset: Offset
-          ID to start listing from (omit for latest), limit: List page size (default:
-          5)'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - default: thread=,offset=,limit=5
+          description:
+            "thread: Thread ID (can also use 'default'), offset: Offset
+            ID to start listing from (omit for latest), limit: List page size (default:
+            5)"
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: blocks
           schema:
             $ref: '#/definitions/pb.BlockList'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Paginates blocks in a thread
       tags:
-      - blocks
+        - blocks
   /blocks/{id}:
     delete:
       description: Removes a thread block by ID
       parameters:
-      - description: block id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: block id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: block
           schema:
             $ref: '#/definitions/pb.Block'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Remove thread block
       tags:
-      - blocks
+        - blocks
     get:
       description: Gets a thread block by ID
       parameters:
-      - description: block id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: block id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: block
           schema:
             $ref: '#/definitions/pb.Block'
             type: object
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
       summary: Gets thread block
       tags:
-      - blocks
+        - blocks
   /blocks/{id}/comment:
     get:
       description: Gets a thread comment by block ID
       parameters:
-      - description: block id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: block id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: comment
           schema:
             $ref: '#/definitions/pb.Comment'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Get thread comment
       tags:
-      - blocks
+        - blocks
   /blocks/{id}/comments:
     get:
       description: Lists comments on a thread block
       parameters:
-      - description: block id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: block id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: comments
           schema:
             $ref: '#/definitions/pb.CommentList'
             type: object
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: List comments
       tags:
-      - blocks
+        - blocks
     post:
       description: Adds a comment to a thread block
       parameters:
-      - description: block id
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: urlescaped comment body
-        in: header
-        name: X-Textile-Args
-        required: true
-        type: string
+        - description: block id
+          in: path
+          name: id
+          required: true
+          type: string
+        - description: urlescaped comment body
+          in: header
+          name: X-Textile-Args
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: comment
           schema:
             $ref: '#/definitions/pb.Comment'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Add a comment
       tags:
-      - blocks
+        - blocks
   /blocks/{id}/like:
     get:
       description: Gets a thread like by block ID
       parameters:
-      - description: block id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: block id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: like
           schema:
             $ref: '#/definitions/pb.Like'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Get thread like
       tags:
-      - blocks
+        - blocks
   /blocks/{id}/likes:
     get:
       description: Lists likes on a thread block
       parameters:
-      - description: block id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: block id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: likes
           schema:
             $ref: '#/definitions/pb.LikeList'
             type: object
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: List likes
       tags:
-      - blocks
+        - blocks
     post:
       description: Adds a like to a thread block
       parameters:
-      - description: block id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: block id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: like
           schema:
             $ref: '#/definitions/pb.Like'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Add a like
       tags:
-      - blocks
+        - blocks
   /cafes:
     get:
       description: |-
         List info about all active cafe sessions. Cafes are other peers on the network
         who offer pinning, backup, and inbox services
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: cafe sessions
           schema:
             $ref: '#/definitions/pb.CafeSessionList'
             type: object
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: List info about all active cafe sessions
       tags:
-      - cafes
+        - cafes
     post:
       description: |-
         Registers with a cafe and saves an expiring service session token. An access
         token is required to register, and should be obtained separately from the target
         Cafe
       parameters:
-      - description: cafe host
-        in: header
-        name: X-Textile-Args
-        required: true
-        type: string
-      - default: token=
-        description: 'token: An access token supplied by the Cafe'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - description: cafe host
+          in: header
+          name: X-Textile-Args
+          required: true
+          type: string
+        - default: token=
+          description: 'token: An access token supplied by the Cafe'
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: cafe session
           schema:
             $ref: '#/definitions/pb.CafeSession'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Register with a Cafe
       tags:
-      - cafes
+        - cafes
   /cafes/{id}:
     delete:
-      description: Deregisters with a cafe (content will expire based on the cafe's
+      description:
+        Deregisters with a cafe (content will expire based on the cafe's
         service rules)
       parameters:
-      - description: cafe id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: cafe id
+          in: path
+          name: id
+          required: true
+          type: string
       responses:
-        "204":
+        '204':
           description: ok
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Deregisters a cafe
       tags:
-      - cafes
+        - cafes
     get:
       description: |-
         Gets and displays info about a cafe session. Cafes are other peers on the network
         who offer pinning, backup, and inbox services
       parameters:
-      - description: cafe id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: cafe id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: cafe session
           schema:
             $ref: '#/definitions/pb.CafeSession'
             type: object
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Gets and displays info about a cafe session
       tags:
-      - cafes
+        - cafes
   /cafes/messages:
     post:
       description: |-
         Check for messages at all cafes. New messages are downloaded and processed
         opportunistically.
       produces:
-      - text/plain
+        - text/plain
       responses:
-        "200":
+        '200':
           description: ok
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Check for messages at all cafes
       tags:
-      - cafes
+        - cafes
   /config:
     patch:
       consumes:
-      - application/json
+        - application/json
       description: |-
         When patching config values, valid JSON types must be used. For example, a string
         should be escaped or wrapped in single quotes (e.g., \"127.0.0.1:40600\") and
@@ -948,208 +950,209 @@ paths:
         wrapped in single quotes. Be sure to restart the daemon for changes to take effect.
         See https://tools.ietf.org/html/rfc6902 for details on RFC6902 JSON patch format.
       parameters:
-      - description: An RFC6902 JSON patch (array of ops)
-        in: body
-        name: patch
-        required: true
-        schema:
-          $ref: '#/definitions/mill.Json'
-          type: object
+        - description: An RFC6902 JSON patch (array of ops)
+          in: body
+          name: patch
+          required: true
+          schema:
+            $ref: '#/definitions/mill.Json'
+            type: object
       responses:
-        "204":
+        '204':
           description: No Content
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Set/update config settings
       tags:
-      - config
+        - config
     put:
       consumes:
-      - application/json
+        - application/json
       description: |-
         Replace entire config file contents. The config command controls configuration
         variables. It works much like 'git config'. The configuration values are stored
         in a config file inside the Textile repository.
       parameters:
-      - description: JSON document
-        in: body
-        name: config
-        required: true
-        schema:
-          $ref: '#/definitions/mill.Json'
-          type: object
+        - description: JSON document
+          in: body
+          name: config
+          required: true
+          schema:
+            $ref: '#/definitions/mill.Json'
+            type: object
       responses:
-        "204":
+        '204':
           description: No Content
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Replace config settings.
       tags:
-      - config
+        - config
   /config/{path}:
     get:
       description: |-
         Report the currently active config settings, which may differ from the values
         specifed when setting/patching values.
       parameters:
-      - description: config path (e.g., Addresses/API)
-        in: path
-        name: path
-        type: string
+        - description: config path (e.g., Addresses/API)
+          in: path
+          name: path
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: new config value
           schema:
             $ref: '#/definitions/mill.Json'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Get active config settings
       tags:
-      - config
+        - config
   /contacts:
     get:
       description: Lists known contacts.
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: contacts
           schema:
             $ref: '#/definitions/pb.ContactList'
             type: object
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: List known contacts
       tags:
-      - contacts
+        - contacts
   /contacts/{address}:
     delete:
       description: Removes a known contact
       parameters:
-      - description: address
-        in: path
-        name: address
-        required: true
-        type: string
+        - description: address
+          in: path
+          name: address
+          required: true
+          type: string
       responses:
-        "204":
+        '204':
           description: ok
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Remove a contact
       tags:
-      - contacts
+        - contacts
     get:
       description: Gets a known contact
       parameters:
-      - description: address
-        in: path
-        name: address
-        required: true
-        type: string
+        - description: address
+          in: path
+          name: address
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: contact
           schema:
             $ref: '#/definitions/pb.Contact'
             type: object
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
       summary: Get a known contact
       tags:
-      - contacts
+        - contacts
     put:
       consumes:
-      - application/json
+        - application/json
       description: Adds a contact by username or account address to known contacts.
       parameters:
-      - description: address
-        in: path
-        name: address
-        required: true
-        type: string
-      - description: contact
-        in: body
-        name: contact
-        required: true
-        schema:
-          $ref: '#/definitions/pb.Contact'
-          type: object
+        - description: address
+          in: path
+          name: address
+          required: true
+          type: string
+        - description: contact
+          in: body
+          name: contact
+          required: true
+          schema:
+            $ref: '#/definitions/pb.Contact'
+            type: object
       responses:
-        "204":
+        '204':
           description: ok
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Add to known contacts
       tags:
-      - contacts
+        - contacts
   /contacts/search:
     post:
       description: Search for contacts known locally and on the network
       parameters:
-      - default: local="false",limit=5,wait=5,address=,username=,events="false"
-        description: 'local: Whether to only search local contacts, remote: Whether
-          to only search remote contacts, limit: Stops searching after limit results
-          are found, wait: Stops searching after ''wait'' seconds have elapsed (max
-          30s), username: search by username string, address: search by account address
-          string, events: Whether to emit Server-Sent Events (SSEvent) or plain JSON'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - default: local="false",limit=5,wait=5,address=,username=,events="false"
+          description:
+            "local: Whether to only search local contacts, remote: Whether
+            to only search remote contacts, limit: Stops searching after limit results
+            are found, wait: Stops searching after 'wait' seconds have elapsed (max
+            30s), username: search by username string, address: search by account address
+            string, events: Whether to emit Server-Sent Events (SSEvent) or plain JSON"
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: results stream
           schema:
             $ref: '#/definitions/pb.QueryResult'
             type: object
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Search for contacts
       tags:
-      - contacts
+        - contacts
   /feed:
     get:
       description: |-
@@ -1168,808 +1171,821 @@ paths:
         position in the stack. Additional annotations are nested under the target.
         Newer annotations may have already been listed in the case as well.
       parameters:
-      - default: thread=,offset=,limit=5,mode="chrono"
-        description: 'thread: Thread ID (can also use ''default''), offset: Offset
-          ID to start listing from (omit for latest), limit: List page size (default:
-          5), mode: Feed mode (one of ''chrono'', ''annotated'', or ''stacks'')'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - default: thread=,offset=,limit=5,mode="chrono"
+          description:
+            "thread: Thread ID (can also use 'default'), offset: Offset
+            ID to start listing from (omit for latest), limit: List page size (default:
+            5), mode: Feed mode (one of 'chrono', 'annotated', or 'stacks')"
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: feed
           schema:
             $ref: '#/definitions/pb.FeedItemList'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Paginates post and annotation block types
       tags:
-      - feed
+        - feed
   /files:
     get:
       description: |-
         Paginates thread files. If thread id not provided, paginate all files. Specify
         "default" to use the default thread (if set).
       parameters:
-      - default: thread=,offset=,limit=5
-        description: 'thread: Thread ID. Omit for all, offset: Offset ID to start
-          listing from. Omit for latest, limit: List page size. (default: 5)'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - default: thread=,offset=,limit=5
+          description:
+            'thread: Thread ID. Omit for all, offset: Offset ID to start
+            listing from. Omit for latest, limit: List page size. (default: 5)'
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: files
           schema:
             $ref: '#/definitions/pb.FilesList'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Paginates thread files
       tags:
-      - files
+        - files
   /files/{block}:
     get:
       description: Gets a thread file by block ID
       parameters:
-      - description: block id
-        in: path
-        name: block
-        required: true
-        type: string
+        - description: block id
+          in: path
+          name: block
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: file
           schema:
             $ref: '#/definitions/pb.Files'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Get thread file
       tags:
-      - files
+        - files
   /invites:
     get:
       description: Lists all pending thread invites
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: invites
           schema:
             $ref: '#/definitions/pb.InviteViewList'
             type: object
       summary: List invites
       tags:
-      - invites
+        - invites
     post:
       description: Creates a direct account-to-account or external invite to a thread
       parameters:
-      - default: thread=,address=
-        description: 'thread: Thread ID (can also use ''default''), address: Account
-          Address (omit to create an external invite)'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - default: thread=,address=
+          description:
+            "thread: Thread ID (can also use 'default'), address: Account
+            Address (omit to create an external invite)"
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: invite
           schema:
             $ref: '#/definitions/pb.ExternalInvite'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Create an invite to a thread
       tags:
-      - invites
+        - invites
   /invites/{id}/accept:
     post:
       description: |-
         Accepts a direct peer-to-peer or external invite to a thread. Use the key option
         with an external invite
       parameters:
-      - description: invite id
-        in: path
-        name: id
-        required: true
-        type: string
-      - default: key=
-        description: 'key: key for an external invite'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - description: invite id
+          in: path
+          name: id
+          required: true
+          type: string
+        - default: key=
+          description: 'key: key for an external invite'
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: join block
           schema:
             $ref: '#/definitions/pb.Block'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "409":
+        '409':
           description: Conflict
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Accept a thread invite
       tags:
-      - invites
+        - invites
   /invites/{id}/ignore:
     post:
       description: Ignores a direct peer-to-peer invite to a thread
       parameters:
-      - description: invite id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: invite id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: ok
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Ignore a thread invite
       tags:
-      - invites
+        - invites
   /ipfs/cat/{path}:
     get:
       description: Displays the data behind an IPFS CID (hash) or Path
       parameters:
-      - description: ipfs/ipns cid
-        in: path
-        name: path
-        required: true
-        type: string
-      - default: key=
-        description: 'key: Key to decrypt data on-the-fly'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - description: ipfs/ipns cid
+          in: path
+          name: path
+          required: true
+          type: string
+        - default: key=
+          description: 'key: Key to decrypt data on-the-fly'
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/octet-stream
+        - application/octet-stream
       responses:
-        "200":
+        '200':
           description: data
           schema:
             items:
               type: integer
             type: array
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "401":
+        '401':
           description: Unauthorized
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Cat IPFS data
       tags:
-      - ipfs
+        - ipfs
   /ipfs/id:
     get:
       description: Displays underlying IPFS peer ID
       produces:
-      - text/plain
+        - text/plain
       responses:
-        "200":
+        '200':
           description: peer id
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Get IPFS peer ID
       tags:
-      - ipfs
+        - ipfs
   /ipfs/swarm/connect:
     post:
       description: Opens a new direct connection to a peer using an IPFS multiaddr
       parameters:
-      - description: peer address
-        in: header
-        name: X-Textile-Args
-        required: true
-        type: string
+        - description: peer address
+          in: header
+          name: X-Textile-Args
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: ok
           schema:
             items:
               type: string
             type: array
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Opens a new direct connection to a peer address
       tags:
-      - ipfs
+        - ipfs
   /ipfs/swarm/peers:
     get:
       description: Lists the set of peers this node is connected to
       parameters:
-      - default: verbose="false",latency="false",streams="false",direction="false"
-        description: 'verbose: Display all extra information, latency: Also list information
-          about latency to each peer, streams: Also list information about open streams
-          for each peer, direction: Also list information about the direction of connection'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - default: verbose="false",latency="false",streams="false",direction="false"
+          description:
+            'verbose: Display all extra information, latency: Also list information
+            about latency to each peer, streams: Also list information about open streams
+            for each peer, direction: Also list information about the direction of connection'
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: connection
           schema:
             $ref: '#/definitions/ipfs.ConnInfos'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: List swarm peers
       tags:
-      - ipfs
+        - ipfs
   /keys/{target}:
     get:
       description: Shows file keys under the given target from an add
       parameters:
-      - description: target id
-        in: path
-        name: target
-        required: true
-        type: string
+        - description: target id
+          in: path
+          name: target
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: keys
           schema:
             $ref: '#/definitions/pb.Keys'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Show file keys
       tags:
-      - files
+        - files
   /logs/{subsystem}:
     post:
       description: |-
         List or change the verbosity of one or all subsystems log output. Textile logs
         piggyback on the IPFS event logs
       parameters:
-      - description: subsystem logging identifier (omit for all)
-        in: path
-        name: subsystem
-        type: string
-      - default: level=,tex-only="false"
-        description: 'level: Log-level (one of: debug, info, warning, error, critical,
-          or '
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - description: subsystem logging identifier (omit for all)
+          in: path
+          name: subsystem
+          type: string
+        - default: level=,tex-only="false"
+          description:
+            'level: Log-level (one of: debug, info, warning, error, critical,
+            or '
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: subsystems
           schema:
             $ref: '#/definitions/core.SubsystemInfo'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Access subsystem logs
       tags:
-      - utils
+        - utils
   /messages:
     get:
       description: Paginates thread messages
       parameters:
-      - default: thread=,offset=,limit=10
-        description: 'thread: Thread ID (can also use ''default'', omit for all),
-          offset: Offset ID to start listing from (omit for latest), limit: List page
-          size (default: 5)'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - default: thread=,offset=,limit=10
+          description:
+            "thread: Thread ID (can also use 'default', omit for all),
+            offset: Offset ID to start listing from (omit for latest), limit: List page
+            size (default: 5)"
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: messages
           schema:
             $ref: '#/definitions/pb.TextList'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Paginates thread messages
       tags:
-      - messages
+        - messages
   /messages/{block}:
     get:
       description: Gets a thread message by block ID
       parameters:
-      - description: block id
-        in: path
-        name: block
-        required: true
-        type: string
+        - description: block id
+          in: path
+          name: block
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: message
           schema:
             $ref: '#/definitions/pb.Text'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Get thread message
       tags:
-      - messages
+        - messages
   /mills/blob:
     post:
       consumes:
-      - multipart/form-data
+        - multipart/form-data
       description: |-
         Takes a binary data blob, and optionally encrypts it, before adding to IPFS,
         and returns a file object
       parameters:
-      - description: multipart/form-data file
-        in: formData
-        name: file
-        type: file
-      - default: plaintext=false,use=""
-        description: 'plaintext: whether to leave unencrypted), use: if empty, assumes
-          body contains multipart form file data, otherwise, will attempt to fetch
-          given CID from IPFS'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - description: multipart/form-data file
+          in: formData
+          name: file
+          type: file
+        - default: plaintext=false,use=""
+          description:
+            'plaintext: whether to leave unencrypted), use: if empty, assumes
+            body contains multipart form file data, otherwise, will attempt to fetch
+            given CID from IPFS'
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: file
           schema:
             $ref: '#/definitions/pb.FileIndex'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Process raw data blobs
       tags:
-      - mills
+        - mills
   /mills/image/exif:
     post:
       consumes:
-      - multipart/form-data
+        - multipart/form-data
       description: |-
         Takes an input image, and extracts its EXIF data (optionally encrypting output),
         before adding to IPFS, and returns a file object
       parameters:
-      - description: multipart/form-data file
-        in: formData
-        name: file
-        type: file
-      - default: plaintext=false,use=""
-        description: 'plaintext: whether to leave unencrypted, use: if empty, assumes
-          body contains multipart form file data, otherwise, will attempt to fetch
-          given CID from IPFS'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - description: multipart/form-data file
+          in: formData
+          name: file
+          type: file
+        - default: plaintext=false,use=""
+          description:
+            'plaintext: whether to leave unencrypted, use: if empty, assumes
+            body contains multipart form file data, otherwise, will attempt to fetch
+            given CID from IPFS'
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: file
           schema:
             $ref: '#/definitions/pb.FileIndex'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Extract EXIF data from image
       tags:
-      - mills
+        - mills
   /mills/image/resize:
     post:
       consumes:
-      - multipart/form-data
+        - multipart/form-data
       description: |-
         Takes an input image, and resizes/resamples it (optionally encrypting output),
         before adding to IPFS, and returns a file object
       parameters:
-      - description: multipart/form-data file
-        in: formData
-        name: file
-        type: file
-      - default: plaintext=false,use="",quality=75,width=100
-        description: 'plaintext: whether to leave unencrypted, use: if empty, assumes
-          body contains multipart form file data, otherwise, will attempt to fetch
-          given CID from IPFS, width: the requested image width (required), quality:
-          the requested JPEG image quality'
-        in: header
-        name: X-Textile-Opts
-        required: true
-        type: string
+        - description: multipart/form-data file
+          in: formData
+          name: file
+          type: file
+        - default: plaintext=false,use="",quality=75,width=100
+          description:
+            'plaintext: whether to leave unencrypted, use: if empty, assumes
+            body contains multipart form file data, otherwise, will attempt to fetch
+            given CID from IPFS, width: the requested image width (required), quality:
+            the requested JPEG image quality'
+          in: header
+          name: X-Textile-Opts
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: file
           schema:
             $ref: '#/definitions/pb.FileIndex'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Resize an image
       tags:
-      - mills
+        - mills
   /mills/json:
     post:
       consumes:
-      - multipart/form-data
+        - multipart/form-data
       description: |-
         Takes an input JSON document, validates it according to its schema.org definition,
         optionally encrypts the output before adding to IPFS, and returns a file object
       parameters:
-      - description: multipart/form-data file
-        in: formData
-        name: file
-        type: file
-      - default: plaintext="false",use=""
-        description: 'plaintext: whether to leave unencrypted, use: if empty, assumes
-          body contains multipart form file data, otherwise, will attempt to fetch
-          given CID from IPFS'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - description: multipart/form-data file
+          in: formData
+          name: file
+          type: file
+        - default: plaintext="false",use=""
+          description:
+            'plaintext: whether to leave unencrypted, use: if empty, assumes
+            body contains multipart form file data, otherwise, will attempt to fetch
+            given CID from IPFS'
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: file
           schema:
             $ref: '#/definitions/pb.FileIndex'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Process input JSON data
       tags:
-      - mills
+        - mills
   /mills/schema:
     post:
       consumes:
-      - application/json
-      description: Takes a JSON-based Schema, validates it, adds it to IPFS, and returns
+        - application/json
+      description:
+        Takes a JSON-based Schema, validates it, adds it to IPFS, and returns
         a file object
       parameters:
-      - description: schema
-        in: body
-        name: schema
-        required: true
-        schema:
-          $ref: '#/definitions/pb.Node'
-          type: object
+        - description: schema
+          in: body
+          name: schema
+          required: true
+          schema:
+            $ref: '#/definitions/pb.Node'
+            type: object
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: file
           schema:
             $ref: '#/definitions/pb.FileIndex'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Validate, add, and pin a new Schema
       tags:
-      - mills
+        - mills
   /notifications:
     get:
       description: Lists all notifications generated by thread and account activity.
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: notifications
           schema:
             $ref: '#/definitions/pb.NotificationList'
             type: object
       summary: List notifications
       tags:
-      - notifications
+        - notifications
   /notifications/{id}/read:
     post:
       description: Marks a notifiction as read by ID. Use 'all' to mark all as read.
       parameters:
-      - description: notification id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: notification id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: ok
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Mark notifiction as read
       tags:
-      - notifications
+        - notifications
   /ping:
     get:
       description: Pings another peer on the network, returning online|offline.
       parameters:
-      - description: peerid
-        in: header
-        name: X-Textile-Args
-        required: true
-        type: string
+        - description: peerid
+          in: header
+          name: X-Textile-Args
+          required: true
+          type: string
       produces:
-      - text/plain
+        - text/plain
       responses:
-        "200":
+        '200':
           description: One of online|offline
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Ping a network peer
       tags:
-      - utils
+        - utils
   /profile:
     get:
       description: Gets the local node's public profile
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: peer
           schema:
             $ref: '#/definitions/pb.Peer'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Get public profile
       tags:
-      - profile
+        - profile
   /profile/avatar:
     post:
-      description: Sets public profile avatar by specifying an existing image file
+      description:
+        Sets public profile avatar by specifying an existing image file
         hash
       parameters:
-      - description: hash
-        in: header
-        name: X-Textile-Args
-        required: true
-        type: string
+        - description: hash
+          in: header
+          name: X-Textile-Args
+          required: true
+          type: string
       produces:
-      - text/plain
+        - text/plain
       responses:
-        "201":
+        '201':
           description: ok
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Set avatar
       tags:
-      - profile
+        - profile
   /profile/name:
     post:
       description: Sets public profile display name to given string
       parameters:
-      - description: name
-        in: header
-        name: X-Textile-Args
-        required: true
-        type: string
+        - description: name
+          in: header
+          name: X-Textile-Args
+          required: true
+          type: string
       produces:
-      - text/plain
+        - text/plain
       responses:
-        "201":
+        '201':
           description: ok
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Set display name
       tags:
-      - profile
+        - profile
   /snapshots:
     post:
       description: Snapshots all threads and pushes to registered cafes
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: ok
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Create thread snapshots
       tags:
-      - threads
+        - threads
   /snapshots/search:
     post:
       description: Searches the network for thread snapshots
       parameters:
-      - default: wait=5,events="false"
-        description: 'wait: Stops searching after ''wait'' seconds have elapsed (max
-          30s), events: Whether to emit Server-Sent Events (SSEvent) or plain JSON'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - default: wait=5,events="false"
+          description:
+            "wait: Stops searching after 'wait' seconds have elapsed (max
+            30s), events: Whether to emit Server-Sent Events (SSEvent) or plain JSON"
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: results stream
           schema:
             $ref: '#/definitions/pb.QueryResult'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Search for thread snapshots
       tags:
-      - threads
+        - threads
   /subscribe/{id}:
     get:
       description: |-
@@ -1977,332 +1993,335 @@ paths:
         when a new block is added to a thread. There are several update types:
         MERGE, IGNORE, FLAG, JOIN, ANNOUNCE, LEAVE, TEXT, FILES, COMMENT, LIKE
       parameters:
-      - description: thread id, omit to stream all events
-        in: path
-        name: id
-        type: string
-      - default: type=,events="false"
-        description: 'type: Or''d list of event types (e.g., FILES|COMMENTS|LIKES)
-          or empty to include all types, events: Whether to emit Server-Sent Events
-          (SSEvent) or plain JSON'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - description: thread id, omit to stream all events
+          in: path
+          name: id
+          type: string
+        - default: type=,events="false"
+          description:
+            "type: Or'd list of event types (e.g., FILES|COMMENTS|LIKES)
+            or empty to include all types, events: Whether to emit Server-Sent Events
+            (SSEvent) or plain JSON"
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: stream of updates
           schema:
             $ref: '#/definitions/pb.FeedItem'
             type: object
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Subscribe to thread updates
       tags:
-      - subscribe
+        - subscribe
   /summary:
     get:
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: summary
           schema:
             $ref: '#/definitions/pb.Summary'
             type: object
       summary: Get a summary of node data
       tags:
-      - utils
+        - utils
   /threads:
     get:
       description: Lists all local threads, returning a ThreadList object
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: threads
           schema:
             $ref: '#/definitions/pb.ThreadList'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Lists info on all threads
       tags:
-      - threads
+        - threads
     post:
       description: |-
         Adds a new Thread with given name, type, and sharing and whitelist options, returning
         a Thread object
       parameters:
-      - description: name
-        in: header
-        name: X-Textile-Args
-        required: true
-        type: string
-      - default: type=private,sharing=not_shared,whitelist=
-        description: 'key: A locally unique key used by an app to identify this thread
-          on recovery, schema: Existing Thread Schema IPFS CID, type: Set the thread
-          type to one of ''private'', ''read_only'', ''public'', or ''open'', sharing:
-          Set the thread sharing style to one of ''not_shared'',''invite_only'', or
-          ''shared'', whitelist: An array of contact addresses. When supplied, the
-          thread will not allow additional peers beyond those in array, useful for
-          1-1 chat/file sharing'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - description: name
+          in: header
+          name: X-Textile-Args
+          required: true
+          type: string
+        - default: type=private,sharing=not_shared,whitelist=
+          description:
+            "key: A locally unique key used by an app to identify this thread
+            on recovery, schema: Existing Thread Schema IPFS CID, type: Set the thread
+            type to one of 'private', 'read_only', 'public', or 'open', sharing:
+            Set the thread sharing style to one of 'not_shared','invite_only', or
+            'shared', whitelist: An array of contact addresses. When supplied, the
+            thread will not allow additional peers beyond those in array, useful for
+            1-1 chat/file sharing"
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: thread
           schema:
             $ref: '#/definitions/pb.Thread'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Adds and joins a new thread
       tags:
-      - threads
+        - threads
   /threads/{id}:
     delete:
       description: Leaves and removes a thread
       parameters:
-      - description: thread id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: thread id
+          in: path
+          name: id
+          required: true
+          type: string
       responses:
-        "204":
+        '204':
           description: ok
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Leave and remove a thread
       tags:
-      - threads
+        - threads
     get:
       description: Gets and displays info about a thread
       parameters:
-      - description: thread id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: thread id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: thread
           schema:
             $ref: '#/definitions/pb.Thread'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Gets a thread
       tags:
-      - threads
+        - threads
     put:
       description: Adds or updates a thread directly, usually from a backup
       parameters:
-      - description: id
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: thread
-        in: body
-        name: thread
-        required: true
-        schema:
-          $ref: '#/definitions/pb.Thread'
-          type: object
+        - description: id
+          in: path
+          name: id
+          required: true
+          type: string
+        - description: thread
+          in: body
+          name: thread
+          required: true
+          schema:
+            $ref: '#/definitions/pb.Thread'
+            type: object
       responses:
-        "204":
+        '204':
           description: ok
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Add or update a thread directly
       tags:
-      - threads
+        - threads
   /threads/{id}/files:
     post:
       consumes:
-      - application/json
+        - application/json
       description: |-
         Adds a file or directory of files to a thread. Files not supported by the thread
         schema are ignored. Nested directories are included. An existing file hash may
         also be used as input.
       parameters:
-      - description: list of milled dirs (output from mill endpoint)
-        in: body
-        name: dir
-        required: true
-        schema:
-          $ref: '#/definitions/pb.DirectoryList'
-          type: object
-      - default: caption=
-        description: 'caption: Caption to add to file(s)'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - description: list of milled dirs (output from mill endpoint)
+          in: body
+          name: dir
+          required: true
+          schema:
+            $ref: '#/definitions/pb.DirectoryList'
+            type: object
+        - default: caption=
+          description: 'caption: Caption to add to file(s)'
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: file
           schema:
             $ref: '#/definitions/pb.Files'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Adds a file or directory of files to a thread
       tags:
-      - threads
+        - threads
   /threads/{id}/messages:
     post:
       description: Adds a message to a thread
       parameters:
-      - description: urlescaped message body
-        in: header
-        name: X-Textile-Args
-        required: true
-        type: string
+        - description: urlescaped message body
+          in: header
+          name: X-Textile-Args
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: message
           schema:
             $ref: '#/definitions/pb.Text'
             type: object
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Add a message
       tags:
-      - threads
+        - threads
   /threads/{id}/name:
     put:
       description: Renames a thread. Only initiators can rename a thread.
       parameters:
-      - description: id
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: name
-        in: header
-        name: X-Textile-Args
-        required: true
-        type: string
+        - description: id
+          in: path
+          name: id
+          required: true
+          type: string
+        - description: name
+          in: header
+          name: X-Textile-Args
+          required: true
+          type: string
       responses:
-        "204":
+        '204':
           description: ok
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
       summary: Rename a thread
       tags:
-      - threads
+        - threads
   /threads/{id}/peers:
     get:
-      description: Lists all peers in a thread, optionally listing peers in the default
+      description:
+        Lists all peers in a thread, optionally listing peers in the default
         thread
       parameters:
-      - description: thread id
-        in: path
-        name: id
-        required: true
-        type: string
+        - description: thread id
+          in: path
+          name: id
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: contacts
           schema:
             $ref: '#/definitions/pb.ContactList'
             type: object
-        "404":
+        '404':
           description: Not Found
           schema:
             type: string
       summary: List all thread peers
       tags:
-      - threads
+        - threads
   /tokens:
     get:
       description: List info about all stored cafe tokens
       produces:
-      - application/json
+        - application/json
       responses:
-        "200":
+        '200':
           description: tokens
           schema:
             items:
               type: string
             type: array
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: List local tokens
       tags:
-      - tokens
+        - tokens
     post:
       description: |-
         Generates an access token (44 random bytes) and saves a bcrypt hashed version for
@@ -2312,71 +2331,72 @@ paths:
         by specifying the 'token' option.
         Tokens allow other peers to register with a Cafe peer.
       parameters:
-      - default: token=,store="true"
-        description: 'token: Use existing token, rather than creating a new one, store:
-          Whether to store the added/generated token to the local db'
-        in: header
-        name: X-Textile-Opts
-        type: string
+        - default: token=,store="true"
+          description:
+            'token: Use existing token, rather than creating a new one, store:
+            Whether to store the added/generated token to the local db'
+          in: header
+          name: X-Textile-Opts
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
-        "201":
+        '201':
           description: token
           schema:
             type: string
-        "400":
+        '400':
           description: Bad Request
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Create an access token
       tags:
-      - tokens
+        - tokens
   /tokens/{id}:
     delete:
       description: Removes an existing cafe token
       parameters:
-      - description: token
-        in: path
-        name: token
-        required: true
-        type: string
+        - description: token
+          in: path
+          name: token
+          required: true
+          type: string
       responses:
-        "204":
+        '204':
           description: ok
           schema:
             type: string
-        "500":
+        '500':
           description: Internal Server Error
           schema:
             type: string
       summary: Removes a cafe token
       tags:
-      - tokens
+        - tokens
     get:
       description: Check validity of existing cafe access token
       parameters:
-      - description: invite id
-        in: path
-        name: token
-        required: true
-        type: string
+        - description: invite id
+          in: path
+          name: token
+          required: true
+          type: string
       produces:
-      - text/plain
+        - text/plain
       responses:
-        "200":
+        '200':
           description: ok
           schema:
             type: string
-        "401":
+        '401':
           description: Unauthorized
           schema:
             type: string
       summary: Check token validity
       tags:
-      - tokens
-swagger: "2.0"
+        - tokens
+swagger: '2.0'

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -181,7 +181,7 @@ func (g *Gateway) profileHandler(c *gin.Context) {
 		return
 	}
 
-	pth, err := ipfs.ResolveIPNS(g.Node.Ipfs(), rootId, time.Second * 30)
+	pth, err := ipfs.ResolveIPNS(g.Node.Ipfs(), rootId, time.Second*30)
 	if err != nil {
 		log.Errorf("error resolving profile %s: %s", c.Param("root"), err)
 		render404(c)

--- a/mobile/scripts/fetch_release.sh
+++ b/mobile/scripts/fetch_release.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 IOS_DIR="${DIR}/../dist/ios"
 ANDROID_DIR="${DIR}/../dist/android"
 VER=$1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "go-textile",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "prettier": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "go-textile",
+  "private": true,
+  "version": "0.0.0",
+  "devDependencies": {
+    "prettier": "^1.17.0"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
+  }
+}

--- a/qa/wallet.sh
+++ b/qa/wallet.sh
@@ -2,47 +2,49 @@
 
 set -e
 
-for i in "$@"
-do
-case ${i} in
-    -n=*|--num=*)
-    num="${i#*=}"
-    shift
-    ;;
-    --wait)
-    wait=yes
-    shift
-    ;;
-    *)
-    ;;
-esac
+for i in "$@"; do
+	case ${i} in
+	-n=* | --num=*)
+		num="${i#*=}"
+		shift
+		;;
+	--wait)
+		wait=yes
+		shift
+		;;
+	*) ;;
+
+	esac
 done
 
-[[ -z "$num" ]] && { echo "Please specify the number of account peers, e.g., -n=3" ; exit 1; }
+[[ -z "$num" ]] && {
+	echo "Please specify the number of account peers, e.g., -n=3"
+	exit 1
+}
 
 declare -a ports
 
 function getPort() {
-    echo $(( ((RANDOM<<15)|RANDOM) % 48128 + 1024 ))
+	echo $((((RANDOM << 15) | RANDOM) % 48128 + 1024))
 }
 
 function getApi() {
-    echo "http://127.0.0.1:${ports[$1]}"
+	echo "http://127.0.0.1:${ports[$1]}"
 }
 
 function createPeer() {
-    repo="/tmp/peer$1"
-    seed="$2"
-    api="$3"
+	repo="/tmp/peer$1"
+	seed="$2"
+	api="$3"
 
-    exec > >(sed "s/^/peer$1: /")
-    exec 2> >(sed "s/^/peer$1: (stderr) /" >&2)
+	exec > >(sed "s/^/peer$1: /")
+	exec 2> >(sed "s/^/peer$1: (stderr) /" >&2)
 
-    rm -rf ${repo}
-    mkdir -p ${repo}
+	rm -rf ${repo}
+	mkdir -p ${repo}
 
-    textile init -s $(echo "$wallet" | tail -n1) -a 127.0.0.1:${api} -g 127.0.0.1:$(getPort) -r ${repo} -d -n
-    textile daemon -r ${repo} -d
+	textile init -s $(echo "$wallet" | tail -n1) -a 127.0.0.1:${api} -g 127.0.0.1:$(getPort) -r ${repo} -d -n
+	textile daemon -r ${repo} -d
 }
 
 trap "exit" INT TERM
@@ -60,28 +62,27 @@ echo ""
 
 thread=""
 
-for i in `seq 0 $((num - 1))`;
-do
-    if [[ "$i" -eq "0" ]]; then
-        ports[i]=40600
-    else
-        ports[i]=$(getPort)
-    fi
-    createPeer ${i} ${seed} ${ports[i]} &
-    sleep 5
+for i in $(seq 0 $((num - 1))); do
+	if [[ "$i" -eq "0" ]]; then
+		ports[i]=40600
+	else
+		ports[i]=$(getPort)
+	fi
+	createPeer ${i} ${seed} ${ports[i]} &
+	sleep 5
 
-    # bootstrap some content on peer 0
-    if [[ "$i" -eq "0" ]]; then
-        # create a private thread
-        thread=$(textile threads add "test" --api=$(getApi i) | jq ".id")
+	# bootstrap some content on peer 0
+	if [[ "$i" -eq "0" ]]; then
+		# create a private thread
+		thread=$(textile threads add "test" --api=$(getApi i) | jq ".id")
 
-        # add a message
-        textile messages add "ping" -t ${thread} --api=$(getApi i)
-    else
-        sleep 5
-        # add a message to synced thread
-        textile messages add "pong" -t ${thread} --api=$(getApi i)
-    fi
+		# add a message
+		textile messages add "ping" -t ${thread} --api=$(getApi i)
+	else
+		sleep 5
+		# add a message to synced thread
+		textile messages add "pong" -t ${thread} --api=$(getApi i)
+	fi
 done
 
 sleep 5
@@ -115,132 +116,130 @@ tpc0=$(echo ${test0} | jq ".peer_count")
 echo ${test0} | jq .
 
 # compare against other peer content
-for i in `seq 1 $((num - 1))`;
-do
-    export API=$(getApi i)
+for i in $(seq 1 $((num - 1))); do
+	export API=$(getApi i)
 
-    # summary
-    summary=$(textile summary)
-    apc=$(echo ${summary} | jq ".account_peer_count")
-    tc=$(echo ${summary} | jq ".thread_count")
-    fc=$(echo ${summary} | jq ".files_count")
-    cc=$(echo ${summary} | jq ".contact_count")
+	# summary
+	summary=$(textile summary)
+	apc=$(echo ${summary} | jq ".account_peer_count")
+	tc=$(echo ${summary} | jq ".thread_count")
+	fc=$(echo ${summary} | jq ".files_count")
+	cc=$(echo ${summary} | jq ".contact_count")
 
-    echo ""
-    echo "--> Checking peer${i}'s account peer count..."
-    if [[ "$apc" -ne "$apc0" ]]; then
-        echo ERROR: peer ${i} has incorrect "account_peer_count": ${apc}. Expected ${apc0}.
-        exit 1
-    else
-        echo "--> Got ${apc} ✓"
-    fi
+	echo ""
+	echo "--> Checking peer${i}'s account peer count..."
+	if [[ "$apc" -ne "$apc0" ]]; then
+		echo ERROR: peer ${i} has incorrect "account_peer_count": ${apc}. Expected ${apc0}.
+		exit 1
+	else
+		echo "--> Got ${apc} ✓"
+	fi
 
-    echo ""
-    echo "--> Checking peer${i}'s thread count..."
-    if [[ "$tc" -ne "$tc0" ]]; then
-        echo ERROR: peer ${i} has incorrect "thread_count": ${tc}. Expected ${tc0}.
-        exit 1
-    else
-        echo "--> Got ${tc} ✓"
-    fi
+	echo ""
+	echo "--> Checking peer${i}'s thread count..."
+	if [[ "$tc" -ne "$tc0" ]]; then
+		echo ERROR: peer ${i} has incorrect "thread_count": ${tc}. Expected ${tc0}.
+		exit 1
+	else
+		echo "--> Got ${tc} ✓"
+	fi
 
-    echo ""
-    echo "--> Checking peer${i}'s files count..."
-    if [[ "$fc" -ne "$fc0" ]]; then
-        echo ERROR: peer ${i} has incorrect "files_count": ${fc}. Expected ${fc0}.
-        exit 1
-    else
-        echo "--> Got ${fc} ✓"
-    fi
+	echo ""
+	echo "--> Checking peer${i}'s files count..."
+	if [[ "$fc" -ne "$fc0" ]]; then
+		echo ERROR: peer ${i} has incorrect "files_count": ${fc}. Expected ${fc0}.
+		exit 1
+	else
+		echo "--> Got ${fc} ✓"
+	fi
 
-    echo ""
-    echo "--> Checking peer${i}'s contact count..."
-    if [[ "$cc" -ne "$cc0" ]]; then
-        echo ERROR: peer ${i} has incorrect "contact_count": ${cc}. Expected ${cc0}.
-        exit 1
-    else
-        echo "--> Got ${cc} ✓"
-    fi
+	echo ""
+	echo "--> Checking peer${i}'s contact count..."
+	if [[ "$cc" -ne "$cc0" ]]; then
+		echo ERROR: peer ${i} has incorrect "contact_count": ${cc}. Expected ${cc0}.
+		exit 1
+	else
+		echo "--> Got ${cc} ✓"
+	fi
 
-    # account thread
-    account=$(textile threads get $(textile config Account.Thread))
-    ath=$(echo ${account} | jq ".head")
-    atbc=$(echo ${account} | jq ".block_count")
-    atpc=$(echo ${account} | jq ".peer_count")
+	# account thread
+	account=$(textile threads get $(textile config Account.Thread))
+	ath=$(echo ${account} | jq ".head")
+	atbc=$(echo ${account} | jq ".block_count")
+	atpc=$(echo ${account} | jq ".peer_count")
 
-    echo ""
-    echo "--> Checking peer${i}'s account thread HEAD..."
-    if [[ "$ath" != "$ath0" ]]; then
-        echo ERROR: peer ${i} has incorrect "head": ${ath}. Expected ${ath0}.
-        exit 1
-    else
-        echo "--> Got ${ath} ✓"
-    fi
+	echo ""
+	echo "--> Checking peer${i}'s account thread HEAD..."
+	if [[ "$ath" != "$ath0" ]]; then
+		echo ERROR: peer ${i} has incorrect "head": ${ath}. Expected ${ath0}.
+		exit 1
+	else
+		echo "--> Got ${ath} ✓"
+	fi
 
-    echo ""
-    echo "--> Checking peer${i}'s account thread block count..."
-    if [[ "$atbc" -ne "$atbc0" ]]; then
-        echo ERROR: peer ${i} has incorrect "block_count": ${atbc}. Expected ${atbc0}.
-        exit 1
-    else
-        echo "--> Got ${atbc} ✓"
-    fi
+	echo ""
+	echo "--> Checking peer${i}'s account thread block count..."
+	if [[ "$atbc" -ne "$atbc0" ]]; then
+		echo ERROR: peer ${i} has incorrect "block_count": ${atbc}. Expected ${atbc0}.
+		exit 1
+	else
+		echo "--> Got ${atbc} ✓"
+	fi
 
-    echo ""
-    echo "--> Checking peer${i}'s account thread peer count..."
-    if [[ "$atpc" -ne "$atpc0" ]]; then
-        echo ERROR: peer ${i} has incorrect "peer_count": ${atpc}. Expected ${atpc0}.
-        exit 1
-    else
-        echo "--> Got ${atpc} ✓"
-    fi
+	echo ""
+	echo "--> Checking peer${i}'s account thread peer count..."
+	if [[ "$atpc" -ne "$atpc0" ]]; then
+		echo ERROR: peer ${i} has incorrect "peer_count": ${atpc}. Expected ${atpc0}.
+		exit 1
+	else
+		echo "--> Got ${atpc} ✓"
+	fi
 
-    # test thread
-    test=$(textile threads get ${thread})
-    th=$(echo ${test} | jq ".head")
-    tbc=$(echo ${test} | jq ".block_count")
-    tpc=$(echo ${test} | jq ".peer_count")
+	# test thread
+	test=$(textile threads get ${thread})
+	th=$(echo ${test} | jq ".head")
+	tbc=$(echo ${test} | jq ".block_count")
+	tpc=$(echo ${test} | jq ".peer_count")
 
-    echo ""
-    echo "--> Checking peer${i}'s test thread HEAD..."
-    if [[ "$th" != "$th0" ]]; then
-        echo ERROR: peer ${i} has incorrect "head": ${th}. Expected ${th0}.
-        exit 1
-    else
-        echo "--> Got ${th} ✓"
-    fi
+	echo ""
+	echo "--> Checking peer${i}'s test thread HEAD..."
+	if [[ "$th" != "$th0" ]]; then
+		echo ERROR: peer ${i} has incorrect "head": ${th}. Expected ${th0}.
+		exit 1
+	else
+		echo "--> Got ${th} ✓"
+	fi
 
-    echo ""
-    echo "--> Checking peer${i}'s test thread block count..."
-    if [[ "$tbc" -ne "$tbc0" ]]; then
-        echo ERROR: peer ${i} has incorrect "block_count": ${tbc}. Expected ${tbc0}.
-        exit 1
-    else
-        echo "--> Got ${tbc} ✓"
-    fi
+	echo ""
+	echo "--> Checking peer${i}'s test thread block count..."
+	if [[ "$tbc" -ne "$tbc0" ]]; then
+		echo ERROR: peer ${i} has incorrect "block_count": ${tbc}. Expected ${tbc0}.
+		exit 1
+	else
+		echo "--> Got ${tbc} ✓"
+	fi
 
-    echo ""
-    echo "--> Checking peer${i}'s test thread peer count..."
-    if [[ "$tpc" -ne "$tpc0" ]]; then
-        echo ERROR: peer ${i} has incorrect "peer_count": ${tpc}. Expected ${tpc0}.
-        exit 1
-    else
-        echo "--> Got ${tpc} ✓"
-    fi
+	echo ""
+	echo "--> Checking peer${i}'s test thread peer count..."
+	if [[ "$tpc" -ne "$tpc0" ]]; then
+		echo ERROR: peer ${i} has incorrect "peer_count": ${tpc}. Expected ${tpc0}.
+		exit 1
+	else
+		echo "--> Got ${tpc} ✓"
+	fi
 done
 
 # draw thread graphs
-for i in `seq 1 $((num - 1))`;
-do
-    export API=$(getApi i)
-    textile blocks ls -t $(textile config Account.Thread) -l 100 -d | dot -Tpng -o /tmp/peer${i}_account_blocks.png
-    textile blocks ls -t ${thread} -l 100 -d | dot -Tpng -o /tmp/peer${i}_thread_blocks.png
+for i in $(seq 1 $((num - 1))); do
+	export API=$(getApi i)
+	textile blocks ls -t $(textile config Account.Thread) -l 100 -d | dot -Tpng -o /tmp/peer${i}_account_blocks.png
+	textile blocks ls -t ${thread} -l 100 -d | dot -Tpng -o /tmp/peer${i}_thread_blocks.png
 done
 
 echo "Success."
 
-if [[ "$wait" = "yes" ]]; then
-    wait
+if [[ "$wait" == "yes" ]]; then
+	wait
 else
-    exit 0
+	exit 0
 fi


### PR DESCRIPTION
Non-functional changes have been applied automatically via editorconfig and prettier, enforcing consistent indentation, line endings, and in some cases code cleanups.

Non-functional changes are:

- Added package.json to ensure consistent prettier version is used between us
- Added installation of prettier via `npm install` to `make setup`
- Added prettier to `make {fmt,lint}`

This knocks off these meta issues for this repository:

- https://github.com/textileio/meta/issues/4
- https://github.com/textileio/meta/issues/3