### PR TITLE
docker: can no longer user make setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@ ENV SRC_DIR /go-textile
 # Download packages first so they can be cached.
 COPY go.mod go.sum $SRC_DIR/
 RUN cd $SRC_DIR \
-&& go mod download
+  && go mod download
 
 COPY . $SRC_DIR
 
 # build source
 RUN cd $SRC_DIR \
-  && make setup \
+  && go get github.com/ahmetb/govvv \
   && make build
 
 # Get su-exec, a very minimal tool for dropping privileges,

--- a/Dockerfile.cafe
+++ b/Dockerfile.cafe
@@ -10,13 +10,13 @@ ENV SRC_DIR /go-textile
 # Download packages first so they can be cached.
 COPY go.mod go.sum $SRC_DIR/
 RUN cd $SRC_DIR \
-&& go mod download
+  && go mod download
 
 COPY . $SRC_DIR
 
 # build source
 RUN cd $SRC_DIR \
-  && make setup \
+  && go get github.com/ahmetb/govvv \
   && make build
 
 # Get su-exec, a very minimal tool for dropping privileges,

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -51,7 +51,7 @@ func (x *chatCmd) Execute(args []string) error {
 	}
 	defer rl.Close()
 
-	updates, err := callSub(x.Thread, []string{"message"})
+	updates, err := callSub(x.Thread, []string{"text"})
 	if err != nil {
 		return err
 	}

--- a/core/thread_adds.go
+++ b/core/thread_adds.go
@@ -57,10 +57,6 @@ func (t *Thread) AddExternalInvite() (mh.Multihash, []byte, error) {
 	t.mux.Lock()
 	defer t.mux.Unlock()
 
-	if !t.shareable(t.config.Account.Address, "") {
-		return nil, nil, ErrNotShareable
-	}
-
 	self := t.datastore.Peers().Get(t.node().Identity.Pretty())
 	msg := &pb.ThreadAdd{
 		Thread:  t.datastore.Threads().Get(t.Id),


### PR DESCRIPTION
Also, sneaks in a couple fixes needed for the docs tour.

- `chat` command was still trying to find "message" updates, not "text".
- Creating external invites need not check sharable status.