### PR TITLE
Removes max lifetime timeout on repo

### DIFF
--- a/repo/db/db.go
+++ b/repo/db/db.go
@@ -5,7 +5,6 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/golang/protobuf/jsonpb"
 	logging "github.com/ipfs/go-log"
@@ -51,7 +50,6 @@ func Create(repoPath, pin string) (*SQLiteDatastore, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn.SetConnMaxLifetime(time.Minute * 30)
 	conn.SetMaxIdleConns(2)
 	conn.SetMaxOpenConns(4)
 	if pin != "" {


### PR DESCRIPTION
Should fix https://github.com/textileio/js-http-client/issues/63. Only seems to be an issue for databases that were initialized with encryption enabled. So wouldn't affect mobile at all. Alternatively to this 'fix' would be to figure out how to re-establish the db connection with encryption properly. I don't see any obvious fixes or issues in https://github.com/mutecomm/go-sqlcipher but might be possible...