### PR TITLE
WIP: core: decrypt blocks

### DIFF
--- a/core/api_files.go
+++ b/core/api_files.go
@@ -145,25 +145,6 @@ func (a *api) lsThreadFiles(g *gin.Context) {
 	pbJSON(g, http.StatusOK, list)
 }
 
-// getThreadFiles godoc
-// @Summary Get thread file
-// @Description Gets a thread file by block ID
-// @Tags files
-// @Produce application/json
-// @Param block path string true "block id"
-// @Success 200 {object} pb.Files "file"
-// @Failure 400 {string} string "Bad Request"
-// @Router /files/{block} [get]
-func (a *api) getThreadFiles(g *gin.Context) {
-	files, err := a.node.File(g.Param("block"))
-	if err != nil {
-		g.String(http.StatusBadRequest, err.Error())
-		return
-	}
-
-	pbJSON(g, http.StatusOK, files)
-}
-
 // lsThreadFileTargetKeys godoc
 // @Summary Show file keys
 // @Description Shows file keys under the given target from an add
@@ -201,7 +182,7 @@ func (a *api) lsThreadFileTargetKeys(g *gin.Context) {
 // @Failure 404 {string} string "Not Found"
 // @Router /file/{hash}/data [get]
 func (a *api) getFileData(g *gin.Context) {
-	reader, file, err := a.node.FileData(g.Param("hash"))
+	reader, file, err := a.node.FileContent(g.Param("hash"))
 	if err != nil {
 		g.String(http.StatusNotFound, err.Error())
 		return

--- a/core/api_mill.go
+++ b/core/api_mill.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	m "github.com/textileio/go-textile/mill"
-	"github.com/textileio/go-textile/pb"
 )
 
 // schemaMill godoc
@@ -216,8 +215,7 @@ func (a *api) jsonMill(g *gin.Context) {
 		conf.Input = body
 
 	} else {
-		var file *pb.FileIndex
-		reader, file, err := a.node.FileData(opts["use"])
+		reader, file, err := a.node.FileContent(opts["use"])
 		if err != nil {
 			g.String(http.StatusBadRequest, err.Error())
 			return

--- a/core/files.go
+++ b/core/files.go
@@ -215,31 +215,36 @@ func (t *Textile) FileIndex(hash string) (*pb.FileIndex, error) {
 	return file, nil
 }
 
-func (t *Textile) FileData(hash string) (io.ReadSeeker, *pb.FileIndex, error) {
+func (t *Textile) FileContent(hash string) (io.ReadSeeker, *pb.FileIndex, error) {
 	file := t.datastore.Files().Get(hash)
 	if file == nil {
 		return nil, nil, ErrFileNotFound
 	}
+	reader, err := t.FileIndexContent(file)
+	return reader, file, err
+}
+
+func (t *Textile)  FileIndexContent(file  *pb.FileIndex) (io.ReadSeeker, error) {
 	fd, err := ipfs.DataAtPath(t.node, file.Hash)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var plaintext []byte
 	if file.Key != "" {
 		key, err := base58.Decode(file.Key)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		plaintext, err = crypto.DecryptAES(fd, key)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	} else {
 		plaintext = fd
 	}
 
-	return bytes.NewReader(plaintext), file, nil
+	return bytes.NewReader(plaintext), nil
 }
 
 func (t *Textile) TargetNodeKeys(node ipld.Node) (*pb.Keys, error) {


### PR DESCRIPTION
Closes #688

# Status

Not yet ready for review. WIP.

#  Changelog

Files:

- Renames `FileData` to `FileContent`
- Introduces `FileIndexContent` helper.

API:

- `/blocks/:id/` redirects to `/blocks/:id/meta ` for b/c
- `/blocks/:id/meta` returns metadata for the block
- `/blocks/:id/files` returns the files for the block
- `/blocks/:id/files/:index/:path/meta` returns the metadata for the path at the block
- `/blocks/:id/files/:index/:path/content` returns the decrypted content for the path at the block
- `/files/:block` redirects to `/blocks/:id/files`

# Todo

- [ ] Tests
- [ ] Documentation for new API methods
- [ ] Accompanying CLI methods