### PR TITLE
core: cli: fix --version flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -625,7 +625,7 @@ The response contains a base58 encoded version of the random bytes token.`)
 
 func Run() error {
 	// config
-	kingpin.Version(common.Version)
+	appCmd.Version(common.Version)
 
 	// commands
 	switch kingpin.MustParse(appCmd.Parse(os.Args[1:])) {

--- a/common/version.go
+++ b/common/version.go
@@ -4,4 +4,4 @@ package common
 var GitCommit, GitBranch, GitState, GitSummary, BuildDate string
 
 // Version is the current application's version literal
-const Version = "0.2.0"
+const Version = "0.2.1"


### PR DESCRIPTION
Fixed v0.2.0 regression where `textile --version` would error with `textile: error: unknown long flag '--version', try --help`.

Bumps version to 0.2.1.