### PR TITLE
Update go-ipfs to v0.4.21 + discovery patch

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -290,7 +290,7 @@ Stacks may include:
 	initRepoPath          = initCmd.Flag("repo-dir", "Specify a custom repository path").Short('r').String()
 	initIpfsServerMode    = initCmd.Flag("server", "Apply IPFS server profile").Bool()
 	initIpfsSwarmPorts    = initCmd.Flag("swarm-ports", "Set the swarm ports (TCP,WS). A random TCP port is chosen by default").String()
-	initLogFiles          = initCmd.Flag("log-files", "If true, writes logs to rolling files, if false, writes logs to stdout").Default("true").Bool()
+	initLogFiles          = initCmd.Flag("log-files", "If true, writes logs to rolling files, if false, writes logs to stdout").Bool()
 	initApiBindAddr       = initCmd.Flag("api-bind-addr", "Set the local API address").Default("127.0.0.1:40600").String()
 	initCafeApiBindAddr   = initCmd.Flag("cafe-bind-addr", "Set the cafe REST API address").Default("0.0.0.0:40601").String()
 	initGatewayBindAddr   = initCmd.Flag("gateway-bind-addr", "Set the IPFS gateway address").Default("127.0.0.1:5050").String()

--- a/common/version.go
+++ b/common/version.go
@@ -4,4 +4,4 @@ package common
 var GitCommit, GitBranch, GitState, GitSummary, BuildDate string
 
 // Version is the current application's version literal
-const Version = "0.2.3"
+const Version = "0.2.4"

--- a/core/cafe_api_v0.go
+++ b/core/cafe_api_v0.go
@@ -165,7 +165,7 @@ func (c *cafeApi) service(g *gin.Context) {
 			log.Debugf("responding with %s to %s", rpmes.Message.Type.String(), mPeer.Pretty())
 
 			g.JSON(http.StatusOK, rpmes)
-			g.Writer.Write([]byte("\n"))
+			_, _ = g.Writer.Write([]byte("\n"))
 		}
 		return true
 	})

--- a/core/cafe_service.go
+++ b/core/cafe_service.go
@@ -379,8 +379,7 @@ func (h *CafeService) notifyClient(pid peer.ID) error {
 	if err != nil {
 		return err
 	}
-
-	return ipfs.Publish(h.service.Node(), client, payload, time.Second*5)
+	return ipfs.Publish(h.service.Node(), client, payload)
 }
 
 // sendCafeRequest sends an authenticated request, retrying once after a session refresh
@@ -752,7 +751,7 @@ func (h *CafeService) publishQuery(req *pb.PubSubQuery) error {
 	if err != nil {
 		return err
 	}
-	return ipfs.Publish(h.service.Node(), topic, payload, 0)
+	return ipfs.Publish(h.service.Node(), topic, payload)
 }
 
 // handleChallenge receives a challenge request
@@ -1395,9 +1394,7 @@ func (h *CafeService) handlePubSubQuery(pid peer.ID, env *pb.Envelope) (*pb.Enve
 		if err != nil {
 			return nil, err
 		}
-		// allow some time for the receiver to collect the response after a connect
-		timeout := time.Duration(int(query.Timeout*2/3) * 1e9)
-		if err := ipfs.Publish(h.service.Node(), query.Topic, payload, timeout); err != nil {
+		if err := ipfs.Publish(h.service.Node(), query.Topic, payload); err != nil {
 			return nil, err
 		}
 	}

--- a/core/config.go
+++ b/core/config.go
@@ -90,6 +90,7 @@ func applySwarmPortConfigOption(rep repo.Repo, ports string) error {
 		ws = parts[1]
 	default:
 		tcp = GetRandomPort()
+		ws = GetRandomPort()
 	}
 
 	list := []string{

--- a/core/config.go
+++ b/core/config.go
@@ -122,7 +122,7 @@ func ensureMobileConfig(repoPath string) error {
 	conf.Swarm.ConnMgr.HighWater = 500
 	conf.Swarm.ConnMgr.GracePeriod = (time.Second * 20).String()
 	conf.Swarm.DisableBandwidthMetrics = true
-	conf.Swarm.EnableAutoRelay = false
+	conf.Swarm.EnableAutoRelay = true
 
 	return rep.SetConfig(conf)
 }
@@ -142,7 +142,7 @@ func ensureServerConfig(repoPath string) error {
 	conf.Addresses.NoAnnounce = config.DefaultServerFilters
 	conf.Swarm.AddrFilters = config.DefaultServerFilters
 	conf.Swarm.DisableNatPortMap = true
-	conf.Swarm.EnableRelayHop = false
+	conf.Swarm.EnableRelayHop = true
 	conf.Swarm.EnableAutoNATService = true
 
 	// tmp. ensure IPFS addresses are available in case we need to

--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,9 @@ require (
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.3.1
 	github.com/ipfs/go-cid v0.0.2
-	github.com/ipfs/go-ipfs v0.4.21-rc3
+	github.com/ipfs/go-ipfs v0.4.21
 	github.com/ipfs/go-ipfs-addr v0.0.1
-	github.com/ipfs/go-ipfs-cmds v0.0.7
+	github.com/ipfs/go-ipfs-cmds v0.0.8
 	github.com/ipfs/go-ipfs-config v0.0.3
 	github.com/ipfs/go-ipfs-files v0.0.3
 	github.com/ipfs/go-ipld-format v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -65,3 +65,5 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3
 )
+
+replace github.com/ipfs/go-ipfs => github.com/sanderpick/go-ipfs v0.4.22-0.20190606034924-0478a0eca246

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/ipfs/go-ds-measure v0.0.1 h1:PrCueug+yZLkDCOthZTXKinuoCal/GvlAT7cNxzr
 github.com/ipfs/go-ds-measure v0.0.1/go.mod h1:wiH6bepKsgyNKpz3nyb4erwhhIVpIxnZbsjN1QpVbbE=
 github.com/ipfs/go-fs-lock v0.0.1 h1:XHX8uW4jQBYWHj59XXcjg7BHlHxV9ZOYs6Y43yb7/l0=
 github.com/ipfs/go-fs-lock v0.0.1/go.mod h1:DNBekbboPKcxs1aukPSaOtFA3QfSdi5C855v0i9XJ8Y=
-github.com/ipfs/go-ipfs v0.4.21-rc3 h1:GeSJJ9+r6nRHlaQNvUB2yAZ2aUQcJs7zuCa1cpMVCuM=
-github.com/ipfs/go-ipfs v0.4.21-rc3/go.mod h1:kh51IS+/hCyR4DLH6+821iiIs/7413OK7ZPRtX4oWkM=
+github.com/ipfs/go-ipfs v0.4.21 h1:KB4k3U90cesx60MwHEOqUoSCquZ+JXXHNdw0HIKBusc=
+github.com/ipfs/go-ipfs v0.4.21/go.mod h1:T9zAmGO+rzbvLjDUm0DHtYXtdT4GhWOZeCPztgmt2V8=
 github.com/ipfs/go-ipfs-addr v0.0.1 h1:DpDFybnho9v3/a1dzJ5KnWdThWD1HrFLpQ+tWIyBaFI=
 github.com/ipfs/go-ipfs-addr v0.0.1/go.mod h1:uKTDljHT3Q3SUWzDLp3aYUi8MrY32fgNgogsIa0npjg=
 github.com/ipfs/go-ipfs-blockstore v0.0.1 h1:O9n3PbmTYZoNhkgkEyrXTznbmktIXif62xLX+8dPHzc=
@@ -254,8 +254,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IW
 github.com/ipfs/go-ipfs-blocksutil v0.0.1/go.mod h1:Yq4M86uIOmxmGPUHv/uI7uKqZNtLb449gwKqXjIsnRk=
 github.com/ipfs/go-ipfs-chunker v0.0.1 h1:cHUUxKFQ99pozdahi+uSC/3Y6HeRpi9oTeUHbE27SEw=
 github.com/ipfs/go-ipfs-chunker v0.0.1/go.mod h1:tWewYK0we3+rMbOh7pPFGDyypCtvGcBFymgY4rSDLAw=
-github.com/ipfs/go-ipfs-cmds v0.0.7 h1:0N2NXxYAZn1kHpHrZMHZYRcVGJSxQogDD89oKc0GZMg=
-github.com/ipfs/go-ipfs-cmds v0.0.7/go.mod h1:E5ou2OpwkAtR8LdneNdq4w1vPcrTWvh/6WPhjxGaX/Y=
+github.com/ipfs/go-ipfs-cmds v0.0.8 h1:ZMo0ZeQOr10ZKY4yxYA3lRHUbnF/ZYcV9cpU0IrlGFI=
+github.com/ipfs/go-ipfs-cmds v0.0.8/go.mod h1:TiK4e7/V31tuEb8YWDF8lN3qrnDH+BS7ZqWIeYJlAs8=
 github.com/ipfs/go-ipfs-config v0.0.1 h1:6ED08emzI1imdsAjixFi2pEyZxTVD5ECKtCOxLBx+Uc=
 github.com/ipfs/go-ipfs-config v0.0.1/go.mod h1:KDbHjNyg4e6LLQSQpkgQMBz6Jf4LXiWAcmnkcwmH0DU=
 github.com/ipfs/go-ipfs-config v0.0.3 h1:Ep4tRdP1iVK76BgOprD9B/qtOEdpno+1Xb57BqydgGk=

--- a/go.sum
+++ b/go.sum
@@ -670,6 +670,7 @@ github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd h1:CmH9+J6ZSsIjUK3dcGsnCnO41eRBOnY12zwkn5qVwgc=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
+github.com/sanderpick/go-ipfs v0.4.22-0.20190606034924-0478a0eca246/go.mod h1:T9zAmGO+rzbvLjDUm0DHtYXtdT4GhWOZeCPztgmt2V8=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/segmentio/ksuid v1.0.2 h1:9yBfKyw4ECGTdALaF09Snw3sLJmYIX6AbPJrAy6MrDc=
 github.com/segmentio/ksuid v1.0.2/go.mod h1:BXuJDr2byAiHuQaQtSKoXh1J0YmUDurywOXgB2w+OSU=

--- a/ipfs/pubsub.go
+++ b/ipfs/pubsub.go
@@ -17,18 +17,10 @@ import (
 const PublishTimeout = time.Second * 5
 
 // Publish publishes data to a topic
-func Publish(node *core.IpfsNode, topic string, data []byte, connectTimeout time.Duration) error {
+func Publish(node *core.IpfsNode, topic string, data []byte) error {
 	api, err := coreapi.NewCoreAPI(node)
 	if err != nil {
 		return err
-	}
-
-	if connectTimeout > 0 {
-		cctx, cancel := context.WithTimeout(node.Context(), connectTimeout)
-		defer cancel()
-		if err := connectToTopicReceiver(node, cctx, topic); err != nil {
-			return err
-		}
 	}
 
 	ctx, pcancel := context.WithTimeout(node.Context(), PublishTimeout)

--- a/repo/config/init_ipfs.go
+++ b/repo/config/init_ipfs.go
@@ -38,6 +38,8 @@ var DefaultServerFilters = []string{
 var TextileBootstrapAddresses = []string{
 	"/ip4/18.144.12.135/tcp/4001/ipfs/12D3KooWGBW3LfzypK3zgV4QxdPyUm3aEuwBDMKRRpCPm9FrJvar",  // us-west-1a
 	"/ip4/13.57.23.210/tcp/4001/ipfs/12D3KooWQue2dSRqnZTVvikoxorZQ5Qyyug3hV65rYnWYpYsNMRE",   // us-west-1c
+	"/ip4/13.56.163.77/tcp/4001/ipfs/12D3KooWFrrmGJcQhE5h6VUvUEXdLH7gPKdWh2q4CEM62rFGcFpr",   // us-west-beta
+	"/ip4/52.53.127.155/tcp/4001/ipfs/12D3KooWGN8VAsPHsHeJtoTbbzsGjs2LTmQZ6wFKvuPich1TYmYY",  // us-west-dev
 	"/ip4/18.221.167.133/tcp/4001/ipfs/12D3KooWERmHT6g4YkrPBTmhfDLjfi8b662vFCfvBXqzcdkPGQn1", // us-east-2a
 	"/ip4/18.224.173.65/tcp/4001/ipfs/12D3KooWLh9Gd4C3knv4XqCyCuaNddfEoSLXgekVJzRyC5vsjv5d",  // us-east-2b
 	"/ip4/35.180.16.103/tcp/4001/ipfs/12D3KooWDhSfXZCBVAK6SNQu7h6mfGCBJtjMS44PW5YA5YCjVmjB",  // eu-west-3a
@@ -146,8 +148,8 @@ func InitIpfs(identity native.Identity, mobile bool, server bool) (*native.Confi
 			},
 			DisableBandwidthMetrics: mobile,
 			DisableNatPortMap:       server,
-			EnableRelayHop:          false,
-			EnableAutoRelay:         false,
+			EnableRelayHop:          server,
+			EnableAutoRelay:         mobile,
 			EnableAutoNATService:    server,
 		},
 		Experimental: native.Experiments{

--- a/repo/config/init_ipfs.go
+++ b/repo/config/init_ipfs.go
@@ -147,7 +147,7 @@ func InitIpfs(identity native.Identity, mobile bool, server bool) (*native.Confi
 			DisableBandwidthMetrics: mobile,
 			DisableNatPortMap:       server,
 			EnableRelayHop:          false,
-			EnableAutoRelay:         mobile,
+			EnableAutoRelay:         false,
 			EnableAutoNATService:    server,
 		},
 		Experimental: native.Experiments{
@@ -164,7 +164,7 @@ func InitIpfs(identity native.Identity, mobile bool, server bool) (*native.Confi
 }
 
 func addressesConfig(server bool) native.Addresses {
-	var noAnnounce []string
+	noAnnounce := make([]string, 0)
 	if server {
 		noAnnounce = DefaultServerFilters
 	}


### PR DESCRIPTION
Re: https://github.com/ipfs/go-ipfs/pull/6415

Also,
- Updates sender handling with the version of `IpfsDHT` used in v0.4.21 (v0.0.13)
- Turns auto relay back on for mobile