### PR TITLE
Escape single quotes in repo pincode

### DIFF
--- a/repo/db/db.go
+++ b/repo/db/db.go
@@ -53,7 +53,7 @@ func Create(repoPath, pin string) (*SQLiteDatastore, error) {
 	conn.SetMaxIdleConns(2)
 	conn.SetMaxOpenConns(4)
 	if pin != "" {
-		p := "pragma key='" + pin + "';"
+		p := "pragma key='" + strings.Replace(pin, "'", "''", -1) + "';"
 		if _, err := conn.Exec(p); err != nil {
 			return nil, err
 		}
@@ -205,7 +205,7 @@ func ConflictError(err error) bool {
 func initDatabaseTables(db *sql.DB, pin string) error {
 	var sqlStmt string
 	if pin != "" {
-		sqlStmt = "PRAGMA key = '" + pin + "';"
+		sqlStmt = "pragma key = '" + strings.Replace(pin, "'", "''", -1) + "';"
 	}
 	sqlStmt += `
     create table config (key text primary key not null, value blob);


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

Question: Do we think we need to include this fix in the migration files? Since we've never really enabled passwords before, we're probably ok? But happy to blast this in there if we want to be on the safe side.