### PR TITLE
cli: docs: output valid html

### DIFF
--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -122,7 +122,7 @@ func formatCommand(appCmd *kingpin.Application, i interface{}) string {
 
 	level := depth + 1
 	line := fmt.Sprintf("\n<h%d>%s</h%d>", level, html.EscapeString(fullCommand), level)
-	line += "\n<p><pre>" + html.EscapeString(strings.TrimSpace(help)) + "</pre></p>"
+	line += "\n<pre>" + html.EscapeString(strings.TrimSpace(help)) + "</pre>"
 	details := formatFlags(flags) + formatArgs(args)
 	if details != "" {
 		line += "\n<table>" + details + "\n</table>"

--- a/common/version.go
+++ b/common/version.go
@@ -4,4 +4,4 @@ package common
 var GitCommit, GitBranch, GitState, GitSummary, BuildDate string
 
 // Version is the current application's version literal
-const Version = "0.6.0"
+const Version = "0.6.1"


### PR DESCRIPTION
# Changelog

## Internal Changes

- `textile docs` now outputs valid HTML
  - It no longer outputs `<pre>` elements inside `<p>` elements
  - This is half of the fix for the TOC not rendering on our website

## References

- Workaround https://github.com/Python-Markdown/markdown/issues/830
- Closes https://github.com/textileio/docs/issues/95