### PR TITLE
Unblock threads

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -4,4 +4,4 @@ package common
 var GitCommit, GitBranch, GitState, GitSummary, BuildDate string
 
 // Version is the current application's version literal
-const Version = "0.6.1"
+const Version = "0.6.2"

--- a/core/api_files.go
+++ b/core/api_files.go
@@ -153,7 +153,7 @@ func (a *api) lsThreadFiles(g *gin.Context) {
 func (a *api) lsThreadFileTargetKeys(g *gin.Context) {
 	target := g.Param("target")
 
-	node, err := ipfs.NodeAtPath(a.node.Ipfs(), target)
+	node, err := ipfs.NodeAtPath(a.node.Ipfs(), target, ipfs.CatTimeout)
 	if err != nil {
 		g.String(http.StatusBadRequest, err.Error())
 		return

--- a/core/api_threads.go
+++ b/core/api_threads.go
@@ -162,11 +162,11 @@ func (a *api) lsThreads(g *gin.Context) {
 	}
 	for _, thrd := range a.node.Threads() {
 		view, err := a.node.ThreadView(thrd.Id)
-		if err != nil {
-			a.abort500(g, err)
-			return
+		if err == nil {
+			views.Items = append(views.Items, view)
+		} else {
+			log.Errorf("error getting thread view %s: %s", thrd.Id, err)
 		}
-		views.Items = append(views.Items, view)
 	}
 
 	pbJSON(g, http.StatusOK, views)

--- a/core/invites.go
+++ b/core/invites.go
@@ -123,7 +123,7 @@ func (t *Textile) AcceptInvite(id string) (mh.Multihash, error) {
 // AcceptExternalInvite attemps to download an encrypted thread key from an external invite,
 // adds a new thread, and notifies the inviter of the join
 func (t *Textile) AcceptExternalInvite(id string, key []byte) (mh.Multihash, error) {
-	node, err := ipfs.NodeAtPath(t.node, fmt.Sprintf("%s", id))
+	node, err := ipfs.NodeAtPath(t.node, fmt.Sprintf("%s", id), ipfs.CatTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/core/main.go
+++ b/core/main.go
@@ -377,13 +377,6 @@ func (t *Textile) Start() error {
 		}
 		log.Info("node is online")
 
-		// tmp. publish contact for migrated users.
-		// this normally only happens when peer details are changed,
-		// will be removed at some point in the future.
-		err = t.publishPeer()
-		if err != nil {
-			log.Errorf(err.Error())
-		}
 		go t.cafeOutbox.Flush()
 	}()
 

--- a/core/thread.go
+++ b/core/thread.go
@@ -228,7 +228,7 @@ func (t *Thread) followParents(parents []string) []string {
 
 // followParent tries to follow a tree of blocks, processing along the way
 func (t *Thread) followParent(parent string) ([]string, error) {
-	node, err := ipfs.NodeAtPath(t.node(), parent)
+	node, err := ipfs.NodeAtPath(t.node(), parent, ipfs.CatTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -969,7 +969,7 @@ func extractNode(ipfsNode *core.IpfsNode, node ipld.Node, downloadBlock bool) (*
 
 // blockCIDFromNode returns the inner block id from its ipld wrapper
 func blockCIDFromNode(ipfsNode *core.IpfsNode, nhash string) (string, error) {
-	node, err := ipfs.NodeAtPath(ipfsNode, nhash)
+	node, err := ipfs.NodeAtPath(ipfsNode, nhash, ipfs.DefaultTimeout)
 	if err != nil {
 		return "", err
 	}

--- a/core/thread_ignores.go
+++ b/core/thread_ignores.go
@@ -104,7 +104,7 @@ func (t *Thread) ignoreBlockTarget(block *pb.Block) error {
 			return nil
 		}
 
-		node, err := ipfs.NodeAtPath(t.node(), block.Data)
+		node, err := ipfs.NodeAtPath(t.node(), block.Data, ipfs.CatTimeout)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -43,15 +43,12 @@ require (
 	github.com/kkdai/bstream v0.0.0-20181106074824-b3251f7901ec // indirect
 	github.com/libp2p/go-conn-security v0.0.1 // indirect
 	github.com/libp2p/go-libp2p-core v0.0.4
-	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-host v0.0.3 // indirect
 	github.com/libp2p/go-libp2p-interface-connmgr v0.0.5 // indirect
 	github.com/libp2p/go-libp2p-interface-pnet v0.0.1 // indirect
 	github.com/libp2p/go-libp2p-metrics v0.0.1 // indirect
 	github.com/libp2p/go-libp2p-net v0.0.2 // indirect
-	github.com/libp2p/go-libp2p-peer v0.2.0
-	github.com/libp2p/go-libp2p-peerstore v0.1.2-0.20190621130618-cfa9bb890c1a
-	github.com/libp2p/go-libp2p-protocol v0.1.0
+	github.com/libp2p/go-libp2p-protocol v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-record v0.1.0
 	github.com/libp2p/go-libp2p-transport v0.0.5 // indirect
 	github.com/libp2p/go-stream-muxer v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -457,6 +457,7 @@ github.com/libp2p/go-libp2p-autonat-svc v0.1.0 h1:28IM7iWMDclZeVkpiFQaWVANwXwE7z
 github.com/libp2p/go-libp2p-autonat-svc v0.1.0/go.mod h1:fqi8Obl/z3R4PFVLm8xFtZ6PBL9MlV/xumymRFkKq5A=
 github.com/libp2p/go-libp2p-blankhost v0.0.1 h1:/mZuuiwntNR8RywnCFlGHLKrKLYne+qciBpQXWqp5fk=
 github.com/libp2p/go-libp2p-blankhost v0.0.1/go.mod h1:Ibpbw/7cPPYwFb7PACIWdvxxv0t0XCCI10t7czjAjTc=
+github.com/libp2p/go-libp2p-blankhost v0.1.1 h1:X919sCh+KLqJcNRApj43xCSiQRYqOSI88Fdf55ngf78=
 github.com/libp2p/go-libp2p-blankhost v0.1.1/go.mod h1:pf2fvdLJPsC1FsVrNP3DUUvMzUts2dsLLBEpo1vW1ro=
 github.com/libp2p/go-libp2p-circuit v0.0.1/go.mod h1:Dqm0s/BiV63j8EEAs8hr1H5HudqvCAeXxDyic59lCwE=
 github.com/libp2p/go-libp2p-circuit v0.0.7/go.mod h1:DFCgZ2DklFGTUIZIhSvbbWXTErUgjyNrJGfDHOrTKIA=
@@ -538,6 +539,7 @@ github.com/libp2p/go-libp2p-net v0.0.2 h1:qP06u4TYXfl7uW/hzqPhlVVTSA2nw1B/bHBJaU
 github.com/libp2p/go-libp2p-net v0.0.2/go.mod h1:Yt3zgmlsHOgUWSXmt5V/Jpz9upuJBE8EgNU9DrCcR8c=
 github.com/libp2p/go-libp2p-netutil v0.0.1 h1:LgD6+skofkOx8z6odD9+MZHKjupv3ng1u6KRhaADTnA=
 github.com/libp2p/go-libp2p-netutil v0.0.1/go.mod h1:GdusFvujWZI9Vt0X5BKqwWWmZFxecf9Gt03cKxm2f/Q=
+github.com/libp2p/go-libp2p-netutil v0.1.0 h1:zscYDNVEcGxyUpMd0JReUZTrpMfia8PmLKcKF72EAMQ=
 github.com/libp2p/go-libp2p-netutil v0.1.0/go.mod h1:3Qv/aDqtMLTUyQeundkKsA+YCThNdbQD54k3TqjpbFU=
 github.com/libp2p/go-libp2p-peer v0.0.1/go.mod h1:nXQvOBbwVqoP+T5Y5nCjeH4sP9IX/J0AMzcDUVruVoo=
 github.com/libp2p/go-libp2p-peer v0.1.1 h1:qGCWD1a+PyZcna6htMPo26jAtqirVnJ5NvBQIKV7rRY=
@@ -605,6 +607,7 @@ github.com/libp2p/go-libp2p-swarm v0.1.0/go.mod h1:wQVsCdjsuZoc730CgOvh5ox6K8evl
 github.com/libp2p/go-libp2p-testing v0.0.1/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
 github.com/libp2p/go-libp2p-testing v0.0.2/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
 github.com/libp2p/go-libp2p-testing v0.0.3/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
+github.com/libp2p/go-libp2p-testing v0.0.4 h1:Qev57UR47GcLPXWjrunv5aLIQGO4n9mhI/8/EIrEEFc=
 github.com/libp2p/go-libp2p-testing v0.0.4/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
 github.com/libp2p/go-libp2p-tls v0.0.1 h1:UIslpmpKDbjEymuidtP2D9up00GfWrOs6eyTKf83uBA=
 github.com/libp2p/go-libp2p-tls v0.0.1/go.mod h1:DInSFKxm9XHHSbCdJRbcWctRYkmtPGnqiaUtgjiEa7g=

--- a/ipfs/swarm.go
+++ b/ipfs/swarm.go
@@ -22,7 +22,7 @@ func SwarmConnect(node *core.IpfsNode, addrs []string) ([]string, error) {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(node.Context(), connectTimeout)
+	ctx, cancel := context.WithTimeout(node.Context(), ConnectTimeout)
 	defer cancel()
 
 	output := make([]string, len(pis))
@@ -87,7 +87,7 @@ func SwarmPeers(node *core.IpfsNode, verbose bool, latency bool, streams bool, d
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(node.Context(), connectTimeout)
+	ctx, cancel := context.WithTimeout(node.Context(), ConnectTimeout)
 	defer cancel()
 
 	conns, err := api.Swarm().Peers(ctx)
@@ -144,7 +144,7 @@ func SwarmConnected(node *core.IpfsNode, peerId string) (bool, error) {
 		return false, err
 	}
 
-	ctx, cancel := context.WithTimeout(node.Context(), connectTimeout)
+	ctx, cancel := context.WithTimeout(node.Context(), ConnectTimeout)
 	defer cancel()
 
 	conns, err := api.Swarm().Peers(ctx)

--- a/mobile/files.go
+++ b/mobile/files.go
@@ -171,7 +171,7 @@ func (m *Mobile) imageFileContentForMinWidth(pth string, minWidth int) ([]byte, 
 		return nil, "", core.ErrStopped
 	}
 
-	node, err := ipfs.NodeAtPath(m.node.Ipfs(), pth)
+	node, err := ipfs.NodeAtPath(m.node.Ipfs(), pth, ipfs.CatTimeout)
 	if err != nil {
 		if err == ipld.ErrNotFound {
 			return nil, "", nil
@@ -267,7 +267,7 @@ func (m *Mobile) shareFiles(data string, threadId string, caption string) (mh.Mu
 		return nil, core.ErrThreadNotFound
 	}
 
-	node, err := ipfs.NodeAtPath(m.node.Ipfs(), data)
+	node, err := ipfs.NodeAtPath(m.node.Ipfs(), data, ipfs.CatTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/mobile/threads.go
+++ b/mobile/threads.go
@@ -105,10 +105,11 @@ func (m *Mobile) Threads() ([]byte, error) {
 	}
 	for _, thrd := range m.node.Threads() {
 		view, err := m.node.ThreadView(thrd.Id)
-		if err != nil {
-			return nil, err
+		if err == nil {
+			views.Items = append(views.Items, view)
+		} else {
+			log.Errorf("error getting thread view %s: %s", thrd.Id, err)
 		}
-		views.Items = append(views.Items, view)
 	}
 
 	return proto.Marshal(views)


### PR DESCRIPTION
- Adds a temp solution for unblocking thread listing:
  - Reduce the IPFS timeout to 5 seconds
  - Log an error and return the list of successfully listed threads
- Handles queued blocks concurrently (I noticed that if a post is failing from not being able to cat a block, _all other posts_ will also be blocked)
- Removes the profile publishing that has been happening every time the peer comes online