### PR TITLE
Include failing thread in list

### DIFF
--- a/core/threads.go
+++ b/core/threads.go
@@ -404,13 +404,14 @@ func (t *Textile) ThreadView(id string) (*pb.Thread, error) {
 	mod.SchemaNode = thread.Schema
 	for _, head := range util.SplitString(mod.Head, ",") {
 		hid, err := blockCIDFromNode(t.node, head)
-		if err != nil {
-			return nil, err
-		}
-		block := t.datastore.Blocks().Get(hid)
-		if block != nil {
-			block.User = t.PeerUser(block.Author)
-			mod.HeadBlocks = append(mod.HeadBlocks, block)
+		if err == nil {
+			block := t.datastore.Blocks().Get(hid)
+			if block != nil {
+				block.User = t.PeerUser(block.Author)
+				mod.HeadBlocks = append(mod.HeadBlocks, block)
+			}
+		} else {
+			log.Errorf("error getting node block %s: %s", head, err)
 		}
 	}
 	mod.BlockCount = int32(t.datastore.Blocks().Count(fmt.Sprintf("threadId='%s'", thread.Id)))


### PR DESCRIPTION
One more tweak here @asutula - I realized this temp solution is pretty useless if you're just left in a state where it always takes 5 seconds to list your threads and you're unable to delete the bad thread. So, this just includes the failed thread but w/o it's `head_blocks`, which are not loading from the local repo. 

In the UI, you could check for at least one `head_blocks` item. If missing, render an "alert" icon or something that indicated to the user that they should not expect normal behavior from this thread - in practice, this could just lead you to delete it.