### PR TITLE
search: fix streaming search results

### DIFF
--- a/core/api_search.go
+++ b/core/api_search.go
@@ -38,8 +38,7 @@ func handleSearchStream(g *gin.Context, resultCh <-chan *pb.QueryResult, errCh <
 			if events {
 				g.SSEvent("result", str)
 			} else {
-				g.Data(http.StatusOK, "application/json", []byte(str))
-				g.Writer.Write([]byte("\n"))
+				g.Data(http.StatusOK, "application/json", []byte(str+"\n"))
 			}
 		}
 		return true


### PR DESCRIPTION
I've been trying to track down some flakiness I've seen in the Photos app's contact search. Seemingly, results are not returned when they originate from the requester's cafe. This is a shame because those results should be the most consistent and responsive. As I started to look deeper, I noticed that the streaming HTTP results had stopped working at some point, presumably from an ungraded go version having changed the JSON decoder (?). In any case, this approach was not correct to begin with since the marshaled protobuf messages should not be streamed through a JSON decoder. This is a roundabout way of adding context to what this PR does:
- Properly reads a stream of marshaled protobuf messages by writing fixes length headers followed by the actual bytes

As for the original reason I started digging in here, perhaps this will magically fix that too? Probably not... I'm guessing it's a UI filtering issue... but at least I'll be able to more easily gather info / evidence.