### PR TITLE
Node concurrency

### DIFF
--- a/core/account.go
+++ b/core/account.go
@@ -79,6 +79,9 @@ func (t *Textile) SyncAccount(options *pb.QueryOptions) (*broadcast.Broadcaster,
 
 // maybeSyncAccount runs SyncAccount if it has not been run in the last kSyncAccountFreq
 func (t *Textile) maybeSyncAccount() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
 	if t.cancelSync != nil {
 		t.cancelSync.Close()
 		t.cancelSync = nil

--- a/core/api_blocks.go
+++ b/core/api_blocks.go
@@ -282,7 +282,7 @@ func (a *api) rmBlocks(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	pbJSON(g, http.StatusCreated, block)
 }

--- a/core/api_cafes.go
+++ b/core/api_cafes.go
@@ -48,7 +48,7 @@ func (a *api) addCafes(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	pbJSON(g, http.StatusCreated, session)
 }
@@ -110,7 +110,7 @@ func (a *api) rmCafes(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.Status(http.StatusNoContent)
 }
@@ -131,7 +131,7 @@ func (a *api) checkCafeMessages(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.String(http.StatusOK, "ok")
 }

--- a/core/api_comments.go
+++ b/core/api_comments.go
@@ -49,7 +49,7 @@ func (a *api) addBlockComments(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	pbJSON(g, http.StatusCreated, comment)
 }

--- a/core/api_contacts.go
+++ b/core/api_contacts.go
@@ -38,7 +38,7 @@ func (a *api) addContacts(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.Status(http.StatusNoContent)
 }
@@ -98,7 +98,7 @@ func (a *api) rmContacts(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.Status(http.StatusNoContent)
 }

--- a/core/api_files.go
+++ b/core/api_files.go
@@ -91,7 +91,7 @@ func (a *api) addThreadFiles(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	pbJSON(g, http.StatusCreated, files)
 }

--- a/core/api_invites.go
+++ b/core/api_invites.go
@@ -35,7 +35,7 @@ func (a *api) createInvites(g *gin.Context) {
 		}
 		g.Status(http.StatusCreated)
 
-		go a.node.cafeOutbox.Flush()
+		a.node.FlushCafes()
 		return
 	}
 
@@ -45,7 +45,7 @@ func (a *api) createInvites(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	pbJSON(g, http.StatusCreated, invite)
 }
@@ -112,7 +112,7 @@ func (a *api) acceptInvites(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	pbJSON(g, http.StatusCreated, block)
 }
@@ -134,7 +134,7 @@ func (a *api) ignoreInvites(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.String(http.StatusOK, "ok")
 }

--- a/core/api_likes.go
+++ b/core/api_likes.go
@@ -38,7 +38,7 @@ func (a *api) addBlockLikes(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	pbJSON(g, http.StatusCreated, like)
 }

--- a/core/api_messages.go
+++ b/core/api_messages.go
@@ -49,7 +49,7 @@ func (a *api) addThreadMessages(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	pbJSON(g, http.StatusCreated, msg)
 }

--- a/core/api_profile.go
+++ b/core/api_profile.go
@@ -48,7 +48,7 @@ func (a *api) setName(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.JSON(http.StatusCreated, "ok")
 }
@@ -68,7 +68,7 @@ func (a *api) setAvatar(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.JSON(http.StatusCreated, "ok")
 }

--- a/core/api_snapshots.go
+++ b/core/api_snapshots.go
@@ -23,7 +23,7 @@ func (a *api) createThreadSnapshots(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.String(http.StatusCreated, "ok")
 }

--- a/core/api_threads.go
+++ b/core/api_threads.go
@@ -77,7 +77,7 @@ func (a *api) addThreads(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	pbJSON(g, http.StatusCreated, view)
 }
@@ -112,7 +112,7 @@ func (a *api) addOrUpdateThreads(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.Status(http.StatusNoContent)
 }
@@ -142,7 +142,7 @@ func (a *api) renameThreads(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.Status(http.StatusNoContent)
 }
@@ -238,7 +238,7 @@ func (a *api) rmThreads(g *gin.Context) {
 		return
 	}
 
-	go a.node.cafeOutbox.Flush()
+	a.node.FlushCafes()
 
 	g.Status(http.StatusNoContent)
 }

--- a/core/block_outbox.go
+++ b/core/block_outbox.go
@@ -25,7 +25,11 @@ type BlockOutbox struct {
 }
 
 // NewBlockOutbox creates a new outbox queue
-func NewBlockOutbox(service func() *ThreadsService, node func() *core.IpfsNode, datastore repo.Datastore, cafeOutbox *CafeOutbox) *BlockOutbox {
+func NewBlockOutbox(
+	service func() *ThreadsService,
+	node func() *core.IpfsNode,
+	datastore repo.Datastore,
+	cafeOutbox *CafeOutbox) *BlockOutbox {
 	return &BlockOutbox{
 		service:    service,
 		node:       node,

--- a/core/block_outbox.go
+++ b/core/block_outbox.go
@@ -21,7 +21,7 @@ type BlockOutbox struct {
 	node       func() *core.IpfsNode
 	datastore  repo.Datastore
 	cafeOutbox *CafeOutbox
-	mux        sync.Mutex
+	lock       sync.Mutex
 }
 
 // NewBlockOutbox creates a new outbox queue
@@ -51,8 +51,8 @@ func (q *BlockOutbox) Add(peerId string, env *pb.Envelope) error {
 
 // Flush processes pending messages
 func (q *BlockOutbox) Flush() {
-	q.mux.Lock()
-	defer q.mux.Unlock()
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	log.Debug("flushing block messages")
 
 	if q.service() == nil {

--- a/core/cafe_inbox.go
+++ b/core/cafe_inbox.go
@@ -25,7 +25,7 @@ type CafeInbox struct {
 	node           func() *core.IpfsNode
 	datastore      repo.Datastore
 	checking       bool
-	mux            sync.Mutex
+	lock           sync.Mutex
 }
 
 // NewCafeInbox creates a new inbox queue
@@ -84,8 +84,8 @@ func (q *CafeInbox) Add(msg *pb.CafeMessage) error {
 
 // Flush processes pending messages
 func (q *CafeInbox) Flush() {
-	q.mux.Lock()
-	defer q.mux.Unlock()
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	log.Debug("flushing cafe inbox")
 
 	if q.threadsService() == nil || !q.threadsService().online || q.service() == nil {

--- a/core/cafe_outbox.go
+++ b/core/cafe_outbox.go
@@ -96,7 +96,11 @@ type CafeOutbox struct {
 }
 
 // NewCafeOutbox creates a new outbox queue
-func NewCafeOutbox(node func() *core.IpfsNode, datastore repo.Datastore, handler CafeOutboxHandler, flushBlocks func()) *CafeOutbox {
+func NewCafeOutbox(
+	node func() *core.IpfsNode,
+	datastore repo.Datastore,
+	handler CafeOutboxHandler,
+	flushBlocks func()) *CafeOutbox {
 	return &CafeOutbox{
 		node:        node,
 		datastore:   datastore,

--- a/core/cafe_outbox.go
+++ b/core/cafe_outbox.go
@@ -92,7 +92,7 @@ type CafeOutbox struct {
 	datastore   repo.Datastore
 	handler     CafeOutboxHandler
 	flushBlocks func()
-	mux         sync.Mutex
+	lock        sync.Mutex
 }
 
 // NewCafeOutbox creates a new outbox queue
@@ -172,16 +172,18 @@ func (q *CafeOutbox) AddForInbox(peerId string, env *pb.Envelope, inboxes []*pb.
 }
 
 // Flush processes pending requests
-func (q *CafeOutbox) Flush() {
-	q.mux.Lock()
-	defer q.mux.Unlock()
+func (q *CafeOutbox) Flush(skipBlocks bool) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	log.Debug("flushing cafe outbox")
 
 	if q.handler == nil {
 		return
 	}
 	q.handler.Flush()
-	q.flushBlocks()
+	if !skipBlocks {
+		q.flushBlocks()
+	}
 
 	// clean up
 	err := q.datastore.CafeRequests().DeleteCompleteSyncGroups()

--- a/core/core.go
+++ b/core/core.go
@@ -942,6 +942,7 @@ func setLogLevels(repoPath string, level *pb.LogLevel, disk bool) (io.Writer, er
 		writer = os.Stdout
 	}
 	backendFile := logger.NewLogBackend(writer, "", 0)
+	backendFile.Color = true
 	logger.SetBackend(backendFile)
 	logging.SetAllLoggers(logger.ERROR)
 

--- a/core/core.go
+++ b/core/core.go
@@ -777,15 +777,15 @@ func (t *Textile) runJobs() {
 
 // flushQueues flushes each message queue
 func (t *Textile) flushQueues() {
-	//t.lock.Lock()
-	//defer t.lock.Unlock()
-	//
-	//t.cafeOutbox.Flush()
-	//err := t.cafeInbox.CheckMessages()
-	//if err != nil {
-	//	log.Errorf("error checking messages: %s", err)
-	//}
-	//t.blockDownloads.Flush()
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.cafeOutbox.Flush(false)
+	err := t.cafeInbox.CheckMessages()
+	if err != nil {
+		log.Errorf("error checking messages: %s", err)
+	}
+	t.blockDownloads.Flush()
 }
 
 // threadByBlock returns the thread owning the given block

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -57,7 +57,7 @@ func TestSetLogLevel(t *testing.T) {
 		"tex-datastore": pb.LogLevel_INFO,
 		"tex-service":   pb.LogLevel_DEBUG,
 	}}
-	if err := vars.node.SetLogLevel(logLevel); err != nil {
+	if err := vars.node.SetLogLevel(logLevel, true); err != nil {
 		t.Fatalf("set log levels failed: %s", err)
 	}
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -80,11 +80,6 @@ func TestTextile_API_Addr(t *testing.T) {
 	}
 }
 
-func TestTextile_API_Health(t *testing.T) {
-	addr := "http://" + vars.node.ApiAddr() + "/health"
-	util.TestURL(t, addr)
-}
-
 func TestTextile_API_Stop(t *testing.T) {
 	if err := vars.node.StopApi(); err != nil {
 		t.Errorf("stop api failed: %s", err)

--- a/core/invites.go
+++ b/core/invites.go
@@ -240,7 +240,9 @@ func (t *Textile) handleThreadAdd(plaintext []byte, parents []string) (mh.Multih
 	}
 
 	// handle the thread tail in the background
+	stopLock.Lock()
 	go func() {
+		defer stopLock.Unlock()
 		// follow parents, we don't care about the thread leaves because this is
 		// the first update
 		_ = thread.followParents(parents)

--- a/core/invites.go
+++ b/core/invites.go
@@ -240,9 +240,9 @@ func (t *Textile) handleThreadAdd(plaintext []byte, parents []string) (mh.Multih
 	}
 
 	// handle the thread tail in the background
-	stopLock.Lock()
+	stopLock.Lock("handleAddThread")
 	go func() {
-		defer stopLock.Unlock()
+		defer stopLock.Unlock("handleAddThread")
 		// follow parents, we don't care about the thread leaves because this is
 		// the first update
 		_ = thread.followParents(parents)

--- a/core/search.go
+++ b/core/search.go
@@ -13,7 +13,7 @@ import (
 type queryResultSet struct {
 	options *pb.QueryOptions
 	items   map[string]*pb.QueryResult
-	mux     sync.Mutex
+	lock    sync.Mutex
 }
 
 // newQueryResultSet returns a new queryResultSet
@@ -26,8 +26,8 @@ func newQueryResultSet(options *pb.QueryOptions) *queryResultSet {
 
 // Add only adds a result to the set if it's newer than last
 func (s *queryResultSet) Add(items ...*pb.QueryResult) []*pb.QueryResult {
-	s.mux.Lock()
-	defer s.mux.Unlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
 	var added []*pb.QueryResult
 	for _, i := range items {
@@ -49,8 +49,8 @@ func (s *queryResultSet) Add(items ...*pb.QueryResult) []*pb.QueryResult {
 
 // List returns the items as a slice
 func (s *queryResultSet) List() []*pb.QueryResult {
-	s.mux.Lock()
-	defer s.mux.Unlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
 	var list []*pb.QueryResult
 	for _, i := range s.items {
@@ -62,8 +62,8 @@ func (s *queryResultSet) List() []*pb.QueryResult {
 
 // Full returns whether or not the number of results meets or exceeds limit
 func (s *queryResultSet) Full() bool {
-	s.mux.Lock()
-	defer s.mux.Unlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
 	return len(s.items) >= int(s.options.Limit)
 }

--- a/core/thread.go
+++ b/core/thread.go
@@ -106,7 +106,7 @@ type Thread struct {
 	blockDownloads *BlockDownloads
 	addPeer        func(*pb.Peer) error
 	pushUpdate     func(*pb.Block, string)
-	mux            sync.Mutex
+	lock           sync.Mutex
 }
 
 // NewThread create a new Thread from a repo model and config

--- a/core/thread_adds.go
+++ b/core/thread_adds.go
@@ -10,8 +10,8 @@ import (
 // AddInvite creates an outgoing add block, which is sent directly to the recipient
 // and does not become part of the hash chain
 func (t *Thread) AddInvite(p *pb.Peer) (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	if !t.shareable(t.config.Account.Address, p.Address) {
 		return nil, ErrNotShareable
@@ -63,8 +63,8 @@ func (t *Thread) AddInvite(p *pb.Peer) (mh.Multihash, error) {
 // AddExternalInvite creates an add block, which can be retrieved by any peer
 // and does not become part of the hash chain
 func (t *Thread) AddExternalInvite() (mh.Multihash, []byte, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	self := t.datastore.Peers().Get(t.node().Identity.Pretty())
 	msg := &pb.ThreadAdd{

--- a/core/thread_announces.go
+++ b/core/thread_announces.go
@@ -10,8 +10,8 @@ import (
 
 // announce creates an outgoing announce block
 func (t *Thread) annouce(msg *pb.ThreadAnnounce) (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	if !t.readable(t.config.Account.Address) {
 		return nil, ErrNotReadable

--- a/core/thread_comments.go
+++ b/core/thread_comments.go
@@ -52,9 +52,11 @@ func (t *Thread) handleCommentBlock(block *pb.ThreadBlock) (handleResult, error)
 	var res handleResult
 
 	msg := new(pb.ThreadComment)
-	err := ptypes.UnmarshalAny(block.Payload, msg)
-	if err != nil {
-		return res, err
+	if block.Payload != nil {
+		err := ptypes.UnmarshalAny(block.Payload, msg)
+		if err != nil {
+			return res, err
+		}
 	}
 
 	if !t.readable(t.config.Account.Address) {

--- a/core/thread_comments.go
+++ b/core/thread_comments.go
@@ -10,8 +10,8 @@ import (
 
 // AddComment adds an outgoing comment block
 func (t *Thread) AddComment(target string, body string) (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	if !t.annotatable(t.config.Account.Address) {
 		return nil, ErrNotAnnotatable

--- a/core/thread_files.go
+++ b/core/thread_files.go
@@ -24,8 +24,8 @@ import (
 
 // AddFile adds an outgoing files block
 func (t *Thread) AddFiles(node ipld.Node, target string, caption string, keys map[string]string) (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	if !t.writable(t.config.Account.Address) {
 		return nil, ErrNotWritable

--- a/core/thread_flags.go
+++ b/core/thread_flags.go
@@ -43,9 +43,11 @@ func (t *Thread) handleFlagBlock(block *pb.ThreadBlock) (handleResult, error) {
 	var res handleResult
 
 	msg := new(pb.ThreadFlag)
-	err := ptypes.UnmarshalAny(block.Payload, msg)
-	if err != nil {
-		return res, err
+	if block.Payload != nil {
+		err := ptypes.UnmarshalAny(block.Payload, msg)
+		if err != nil {
+			return res, err
+		}
 	}
 
 	if !t.readable(t.config.Account.Address) {

--- a/core/thread_flags.go
+++ b/core/thread_flags.go
@@ -8,8 +8,8 @@ import (
 
 // AddFlag adds an outgoing flag block targeted at another block to flag
 func (t *Thread) AddFlag(block string) (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	if !t.annotatable(t.config.Account.Address) {
 		return nil, ErrNotAnnotatable

--- a/core/thread_ignores.go
+++ b/core/thread_ignores.go
@@ -57,9 +57,11 @@ func (t *Thread) handleIgnoreBlock(bnode *blockNode, block *pb.ThreadBlock) (han
 	var res handleResult
 
 	msg := new(pb.ThreadIgnore)
-	err := ptypes.UnmarshalAny(block.Payload, msg)
-	if err != nil {
-		return res, err
+	if block.Payload != nil {
+		err := ptypes.UnmarshalAny(block.Payload, msg)
+		if err != nil {
+			return res, err
+		}
 	}
 
 	if !t.readable(t.config.Account.Address) {
@@ -78,7 +80,7 @@ func (t *Thread) handleIgnoreBlock(bnode *blockNode, block *pb.ThreadBlock) (han
 
 	// cleanup
 	target = strings.Replace(target, "ignore-", "", 1)
-	err = t.datastore.Notifications().DeleteByBlock(target)
+	err := t.datastore.Notifications().DeleteByBlock(target)
 	if err != nil {
 		return res, err
 	}

--- a/core/thread_ignores.go
+++ b/core/thread_ignores.go
@@ -11,8 +11,8 @@ import (
 
 // AddIgnore adds an outgoing ignore block targeted at another block to ignore
 func (t *Thread) AddIgnore(block string) (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	if !t.annotatable(t.config.Account.Address) {
 		return nil, ErrNotAnnotatable

--- a/core/thread_joins.go
+++ b/core/thread_joins.go
@@ -10,8 +10,8 @@ import (
 
 // join creates an outgoing join block
 func (t *Thread) join(inviter string) (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	if !t.readable(t.config.Account.Address) {
 		return nil, ErrNotReadable

--- a/core/thread_leaves.go
+++ b/core/thread_leaves.go
@@ -9,8 +9,8 @@ import (
 
 // leave creates an outgoing leave block
 func (t *Thread) leave() (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	if !t.readable(t.config.Account.Address) {
 		return nil, ErrNotReadable

--- a/core/thread_likes.go
+++ b/core/thread_likes.go
@@ -43,9 +43,11 @@ func (t *Thread) handleLikeBlock(block *pb.ThreadBlock) (handleResult, error) {
 	var res handleResult
 
 	msg := new(pb.ThreadLike)
-	err := ptypes.UnmarshalAny(block.Payload, msg)
-	if err != nil {
-		return res, err
+	if block.Payload != nil {
+		err := ptypes.UnmarshalAny(block.Payload, msg)
+		if err != nil {
+			return res, err
+		}
 	}
 
 	if !t.readable(t.config.Account.Address) {

--- a/core/thread_likes.go
+++ b/core/thread_likes.go
@@ -8,8 +8,8 @@ import (
 
 // AddLike adds an outgoing like block
 func (t *Thread) AddLike(target string) (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	if !t.annotatable(t.config.Account.Address) {
 		return nil, ErrNotAnnotatable

--- a/core/thread_messages.go
+++ b/core/thread_messages.go
@@ -10,8 +10,8 @@ import (
 
 // AddMessage adds an outgoing message block
 func (t *Thread) AddMessage(target string, body string) (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 
 	if !t.writable(t.config.Account.Address) {
 		return nil, ErrNotWritable

--- a/core/threads.go
+++ b/core/threads.go
@@ -234,9 +234,9 @@ func (t *Textile) AddOrUpdateThread(thread *pb.Thread) error {
 	}
 
 	// handle the thread tail in the background
-	stopLock.Lock()
+	stopLock.Lock("AddOrUpdateThread")
 	go func() {
-		defer stopLock.Unlock()
+		defer stopLock.Unlock("AddOrUpdateThread")
 
 		leaves := nthread.followParents(heads)
 		err = nthread.handleHead(heads, leaves)

--- a/core/threads.go
+++ b/core/threads.go
@@ -164,9 +164,6 @@ func (t *Textile) AddThread(conf pb.AddThreadConfig, sk libp2pc.PrivKey, initiat
 
 // AddOrUpdateThread add or updates a thread directly, usually from a backup
 func (t *Textile) AddOrUpdateThread(thread *pb.Thread) error {
-	t.mux.Lock()
-	defer t.mux.Unlock()
-
 	// check if we're allowed to get an invite
 	// Note: just using a dummy thread here because having these access+sharing
 	// methods on Thread is very nice elsewhere.
@@ -262,9 +259,6 @@ func (t *Textile) AddOrUpdateThread(thread *pb.Thread) error {
 // RenameThread adds an announce block to the thread w/ a new name
 // Note: Only thread initiators can update the thread's name
 func (t *Textile) RenameThread(id string, name string) error {
-	t.mux.Lock()
-	defer t.mux.Unlock()
-
 	thread := t.Thread(id)
 	if thread == nil {
 		return ErrThreadNotFound
@@ -331,9 +325,6 @@ func (t *Textile) ThreadPeers(id string) (*pb.PeerList, error) {
 // RemoveThread removes a thread
 // @todo rename to abandon to be consistent with CLI+API
 func (t *Textile) RemoveThread(id string) (mh.Multihash, error) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
-
 	var thread *Thread
 	var index int
 	for i, th := range t.loadedThreads {

--- a/core/threads_service.go
+++ b/core/threads_service.go
@@ -229,12 +229,19 @@ func (h *ThreadsService) Handle(env *pb.Envelope, pid peer.ID) (*pb.Envelope, er
 			return nil, err
 		}
 
-		go thread.cafeOutbox.Flush()
+		stopLock.Lock()
+		go func() {
+			defer stopLock.Unlock()
+			thread.cafeOutbox.Flush(false)
+		}()
 		return reply()
 	}
 
 	// handle the thread tail in the background
+	stopLock.Lock()
 	go func() {
+		defer stopLock.Unlock()
+
 		leaves := thread.followParents(bnode.parents)
 		err = thread.handleHead([]string{nhash}, leaves)
 		if err != nil {
@@ -250,7 +257,7 @@ func (h *ThreadsService) Handle(env *pb.Envelope, pid peer.ID) (*pb.Envelope, er
 		}
 
 		// flush cafe queue _at the very end_
-		thread.cafeOutbox.Flush()
+		thread.cafeOutbox.Flush(false)
 	}()
 
 	return reply()

--- a/core/threads_service.go
+++ b/core/threads_service.go
@@ -229,18 +229,18 @@ func (h *ThreadsService) Handle(env *pb.Envelope, pid peer.ID) (*pb.Envelope, er
 			return nil, err
 		}
 
-		stopLock.Lock()
+		stopLock.Lock("ThreadsService.Handle")
 		go func() {
-			defer stopLock.Unlock()
+			defer stopLock.Unlock("ThreadsService.Handle")
 			thread.cafeOutbox.Flush(false)
 		}()
 		return reply()
 	}
 
 	// handle the thread tail in the background
-	stopLock.Lock()
+	stopLock.Lock("ThreadsService.Handle")
 	go func() {
-		defer stopLock.Unlock()
+		defer stopLock.Unlock("ThreadsService.Handle")
 
 		leaves := thread.followParents(bnode.parents)
 		err = thread.handleHead([]string{nhash}, leaves)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/ipfs/go-ipld-format v0.0.2
 	github.com/ipfs/go-log v0.0.1
 	github.com/ipfs/go-merkledag v0.2.0
+	github.com/ipfs/go-metrics-interface v0.0.1
 	github.com/ipfs/go-path v0.0.7
 	github.com/ipfs/go-unixfs v0.2.0
 	github.com/ipfs/interface-go-ipfs-core v0.1.0
@@ -58,6 +59,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.1.0
+	go.uber.org/fx v1.9.0
 	golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443
 	golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f // indirect
 	google.golang.org/appengine v1.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	go.uber.org/fx v1.9.0
 	golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443
 	golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f // indirect
-	golang.org/x/text v0.3.2
 	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	go.uber.org/fx v1.9.0
 	golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443
 	golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f // indirect
+	golang.org/x/text v0.3.2
 	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3

--- a/mobile/cafes.go
+++ b/mobile/cafes.go
@@ -16,8 +16,8 @@ import (
 
 // RegisterCafe is the async flavor of registerCafe
 func (m *Mobile) RegisterCafe(id string, token string, cb Callback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		cb.Call(m.registerCafe(id, token))
@@ -42,8 +42,8 @@ func (m *Mobile) registerCafe(id string, token string) error {
 
 // DeegisterCafe is the async flavor of deregisterCafe
 func (m *Mobile) DeregisterCafe(id string, cb Callback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		cb.Call(m.deregisterCafe(id))
@@ -68,8 +68,8 @@ func (m *Mobile) deregisterCafe(id string) error {
 
 // RefreshCafeSession is the async flavor of refreshCafeSession
 func (m *Mobile) RefreshCafeSession(id string, cb ProtoCallback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		cb.Call(m.refreshCafeSession(id))
@@ -96,8 +96,8 @@ func (m *Mobile) refreshCafeSession(id string) ([]byte, error) {
 
 // CheckCafeMessages calls core CheckCafeMessages
 func (m *Mobile) CheckCafeMessages() error {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		if !m.node.Online() {
@@ -238,8 +238,8 @@ func (m *Mobile) UpdateCafeRequestProgress(id string, transferred int64, total i
 
 // WriteCafeRequest is the async version of writeCafeRequest
 func (m *Mobile) WriteCafeRequest(group string, cb ProtoCallback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		cb.Call(m.writeCafeRequest(group))

--- a/mobile/cafes.go
+++ b/mobile/cafes.go
@@ -16,9 +16,9 @@ import (
 
 // RegisterCafe is the async flavor of registerCafe
 func (m *Mobile) RegisterCafe(id string, token string, cb Callback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		cb.Call(m.registerCafe(id, token))
 	}()
@@ -42,9 +42,9 @@ func (m *Mobile) registerCafe(id string, token string) error {
 
 // DeegisterCafe is the async flavor of deregisterCafe
 func (m *Mobile) DeregisterCafe(id string, cb Callback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		cb.Call(m.deregisterCafe(id))
 	}()
@@ -68,9 +68,9 @@ func (m *Mobile) deregisterCafe(id string) error {
 
 // RefreshCafeSession is the async flavor of refreshCafeSession
 func (m *Mobile) RefreshCafeSession(id string, cb ProtoCallback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		cb.Call(m.refreshCafeSession(id))
 	}()
@@ -96,9 +96,9 @@ func (m *Mobile) refreshCafeSession(id string) ([]byte, error) {
 
 // CheckCafeMessages calls core CheckCafeMessages
 func (m *Mobile) CheckCafeMessages() error {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		if !m.node.Online() {
 			log.Warning("check messages called offline")
@@ -238,9 +238,9 @@ func (m *Mobile) UpdateCafeRequestProgress(id string, transferred int64, total i
 
 // WriteCafeRequest is the async version of writeCafeRequest
 func (m *Mobile) WriteCafeRequest(group string, cb ProtoCallback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		cb.Call(m.writeCafeRequest(group))
 	}()

--- a/mobile/cafes.go
+++ b/mobile/cafes.go
@@ -238,10 +238,7 @@ func (m *Mobile) UpdateCafeRequestProgress(id string, transferred int64, total i
 
 // WriteCafeRequest is the async version of writeCafeRequest
 func (m *Mobile) WriteCafeRequest(group string, cb ProtoCallback) {
-	m.node.Lock()
 	go func() {
-		defer m.node.Unlock()
-
 		cb.Call(m.writeCafeRequest(group))
 	}()
 }

--- a/mobile/cafes_test.go
+++ b/mobile/cafes_test.go
@@ -2,287 +2,294 @@ package mobile
 
 import (
 	"fmt"
-	"net/http"
-	"os"
-	"strings"
-	"testing"
 
-	"github.com/golang/protobuf/proto"
-	icid "github.com/ipfs/go-cid"
-	"github.com/libp2p/go-libp2p-core/peerstore"
-	"github.com/segmentio/ksuid"
-	"github.com/textileio/go-textile/core"
-	"github.com/textileio/go-textile/ipfs"
 	"github.com/textileio/go-textile/pb"
 )
 
-var cafesTestVars = struct {
-	mobilePath  string
-	mobile      *Mobile
-	cafePath    string
-	cafe        *core.Textile
-	cafeApiPort string
-}{
-	mobilePath:  "./testdata/.textile3",
-	cafePath:    "./testdata/.textile4",
-	cafeApiPort: "5000",
-}
-
-func TestMobile_SetupCafes(t *testing.T) {
-	var err error
-	cafesTestVars.mobile, err = createAndStartPeer(InitConfig{
-		RepoPath: cafesTestVars.mobilePath,
-		Debug:    true,
-	}, true, &testHandler{}, &testMessenger{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cafesTestVars.cafe, err = core.CreateAndStartPeer(core.InitConfig{
-		RepoPath:    cafesTestVars.cafePath,
-		Debug:       true,
-		SwarmPorts:  "4001",
-		CafeApiAddr: "0.0.0.0:" + cafesTestVars.cafeApiPort,
-		CafeURL:     "http://127.0.0.1:" + cafesTestVars.cafeApiPort,
-		CafeOpen:    true,
-	}, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestMobile_RegisterCafe(t *testing.T) {
-	token, err := cafesTestVars.cafe.CreateCafeToken("", true)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ok, err := cafesTestVars.cafe.ValidateCafeToken(token)
-	if !ok || err != nil {
-		t.Fatal(err)
-	}
-
-	// register with cafe
-	cafeID := cafesTestVars.cafe.Ipfs().Identity
-	cafesTestVars.mobile.node.Ipfs().Peerstore.AddAddrs(
-		cafeID, cafesTestVars.cafe.Ipfs().PeerHost.Addrs(), peerstore.PermanentAddrTTL)
-	err = cafesTestVars.mobile.registerCafe(cafeID.Pretty(), token)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// add some data
-	err = addTestData(cafesTestVars.mobile)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestMobile_HandleCafeRequests(t *testing.T) {
-	// manually flush until empty
-	err := flush(10)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	m := cafesTestVars.mobile
-	c := cafesTestVars.cafe
-
-	err = m.node.Datastore().CafeRequests().DeleteCompleteSyncGroups()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// ensure all requests have been deleted
-	cnt := m.node.Datastore().CafeRequests().Count(-1)
-	if cnt != 0 {
-		t.Fatalf("expected all requests to be handled, got %d", cnt)
-	}
-
-	// check if blocks are pinned
-	var blocks []string
-	var datas []string
-	list := m.node.Blocks("", -1, "")
-	for _, b := range list.Items {
-		blocks = append(blocks, b.Id)
-		if b.Type == pb.Block_FILES {
-			datas = append(datas, b.Data)
-		}
-	}
-	missingBlockPins, err := ipfs.NotPinned(c.Ipfs(), blocks)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(missingBlockPins) != 0 {
-		var strs []string
-		for _, id := range missingBlockPins {
-			strs = append(strs, id.Hash().B58String())
-		}
-		t.Fatalf("blocks not pinned: %s", strings.Join(strs, ", "))
-	}
-
-	// check if datas are pinned
-	missingDataPins, err := ipfs.NotPinned(c.Ipfs(), datas)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(missingDataPins) != 0 {
-		var strs []string
-		for _, id := range missingDataPins {
-			strs = append(strs, id.Hash().B58String())
-		}
-		t.Fatalf("datas not pinned: %s", strings.Join(strs, ", "))
-	}
-
-	// try unpinning data
-	if len(datas) > 0 {
-		dec, err := icid.Decode(datas[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = ipfs.UnpinCid(c.Ipfs(), dec, true)
-		if err != nil {
-			t.Fatal(err)
-		}
-		not, err := ipfs.NotPinned(c.Ipfs(), []string{datas[0]})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(not) == 0 || not[0].Hash().B58String() != datas[0] {
-			t.Fatal("data was not recursively unpinned")
-		}
-	}
-}
-
-func TestMobile_TeardownCafes(t *testing.T) {
-	_ = cafesTestVars.mobile.Stop()
-	_ = cafesTestVars.cafe.Stop()
-	cafesTestVars.mobile = nil
-	cafesTestVars.cafe = nil
-}
-
-func addTestData(m *Mobile) error {
-	thrd, err := addTestThread(m, &pb.AddThreadConfig{
-		Key:  ksuid.New().String(),
-		Name: "test",
-		Schema: &pb.AddThreadConfig_Schema{
-			Preset: pb.AddThreadConfig_Schema_MEDIA,
-		},
-		Type:    pb.Thread_PRIVATE,
-		Sharing: pb.Thread_INVITE_ONLY,
-	})
-	if err != nil {
-		return err
-	}
-
-	_, err = m.addFiles([]string{"../mill/testdata/image.jpeg"}, thrd.Id, "hi")
-	if err != nil {
-		return err
-	}
-	_, err = m.AddMessage(thrd.Id, "hi")
-	if err != nil {
-		return err
-	}
-	hash, err := m.addFiles([]string{"../mill/testdata/image.png"}, thrd.Id, "hi")
-	if err != nil {
-		return err
-	}
-	_, err = m.AddComment(hash.B58String(), "nice")
-	if err != nil {
-		return err
-	}
-	hash, err = m.addFiles([]string{"../mill/testdata/image.jpeg", "../mill/testdata/image.png"}, thrd.Id, "hi")
-	if err != nil {
-		return err
-	}
-	_, err = m.AddLike(hash.B58String())
-	if err != nil {
-		return err
-	}
-	_, err = m.AddMessage(thrd.Id, "bye")
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-/*
-Handle the request queue.
-  1. List some requests
-  2. Write the HTTP request for each
-  3. Handle them (set to pending, send to cafe)
-  4. Delete failed (reties not handled here)
-  5. Set successful to complete
-*/
-func flushCafeRequests(limit int) (int, error) {
-	var count int
-	res, err := cafesTestVars.mobile.CafeRequests(limit)
-	if err != nil {
-		return count, err
-	}
-	ids := new(pb.Strings)
-	err = proto.Unmarshal(res, ids)
-	if err != nil {
-		return count, err
-	}
-	count = len(ids.Values)
-
-	// write the req for each group
-	reqs := make(map[string]*pb.CafeHTTPRequest)
-	for _, g := range ids.Values {
-		res, err = cafesTestVars.mobile.writeCafeRequest(g)
-		if err != nil {
-			return count, err
-		}
-		req := new(pb.CafeHTTPRequest)
-		err = proto.Unmarshal(res, req)
-		if err != nil {
-			return count, err
-		}
-		reqs[g] = req
-	}
-
-	// mark each as pending (new loops for clarity)
-	for g := range reqs {
-		err = cafesTestVars.mobile.CafeRequestPending(g)
-		if err != nil {
-			return count, err
-		}
-	}
-
-	// handle each
-	for g, req := range reqs {
-		res, err := handleReq(req)
-		if err != nil {
-			return count, err
-		}
-		if res.StatusCode >= 300 {
-			reason := fmt.Sprintf("got bad status: %d\n", res.StatusCode)
-			fmt.Println(reason)
-			err = cafesTestVars.mobile.FailCafeRequest(g, reason)
-		} else {
-			err = cafesTestVars.mobile.CompleteCafeRequest(g)
-		}
-		if err != nil {
-			return count, err
-		}
-		res.Body.Close()
-	}
-	return count, nil
-}
-
-func flush(batchSize int) error {
-	count, err := flushCafeRequests(batchSize)
-	if err != nil {
-		return err
-	}
-	if count > 0 {
-		return flush(batchSize)
-	}
-	return nil
-}
-
+//
+//import (
+//	"fmt"
+//	"net/http"
+//	"os"
+//	"strings"
+//	"testing"
+//
+//	"github.com/golang/protobuf/proto"
+//	icid "github.com/ipfs/go-cid"
+//	"github.com/libp2p/go-libp2p-core/peerstore"
+//	"github.com/segmentio/ksuid"
+//	"github.com/textileio/go-textile/core"
+//	"github.com/textileio/go-textile/ipfs"
+//	"github.com/textileio/go-textile/pb"
+//)
+//
+//var cafesTestVars = struct {
+//	mobilePath  string
+//	mobile      *Mobile
+//	cafePath    string
+//	cafe        *core.Textile
+//	cafeApiPort string
+//}{
+//	mobilePath:  "./testdata/.textile3",
+//	cafePath:    "./testdata/.textile4",
+//	cafeApiPort: "5000",
+//}
+//
+//func TestMobile_SetupCafes(t *testing.T) {
+//	var err error
+//	cafesTestVars.mobile, err = createAndStartPeer(InitConfig{
+//		RepoPath: cafesTestVars.mobilePath,
+//		Debug:    true,
+//	}, true, &testHandler{}, &testMessenger{})
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	cafesTestVars.cafe, err = core.CreateAndStartPeer(core.InitConfig{
+//		RepoPath:    cafesTestVars.cafePath,
+//		Debug:       true,
+//		SwarmPorts:  "4001",
+//		CafeApiAddr: "0.0.0.0:" + cafesTestVars.cafeApiPort,
+//		CafeURL:     "http://127.0.0.1:" + cafesTestVars.cafeApiPort,
+//		CafeOpen:    true,
+//	}, true)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//}
+//
+//func TestMobile_RegisterCafe(t *testing.T) {
+//	token, err := cafesTestVars.cafe.CreateCafeToken("", true)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	ok, err := cafesTestVars.cafe.ValidateCafeToken(token)
+//	if !ok || err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	// register with cafe
+//	cafeID := cafesTestVars.cafe.Ipfs().Identity
+//	cafesTestVars.mobile.node.Ipfs().Peerstore.AddAddrs(
+//		cafeID, cafesTestVars.cafe.Ipfs().PeerHost.Addrs(), peerstore.PermanentAddrTTL)
+//	err = cafesTestVars.mobile.registerCafe(cafeID.Pretty(), token)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	// add some data
+//	err = addTestData(cafesTestVars.mobile)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//}
+//
+//func TestMobile_HandleCafeRequests(t *testing.T) {
+//	// manually flush until empty
+//	err := flush(10)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	m := cafesTestVars.mobile
+//	c := cafesTestVars.cafe
+//
+//	err = m.node.Datastore().CafeRequests().DeleteCompleteSyncGroups()
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	// ensure all requests have been deleted
+//	cnt := m.node.Datastore().CafeRequests().Count(-1)
+//	if cnt != 0 {
+//		t.Fatalf("expected all requests to be handled, got %d", cnt)
+//	}
+//
+//	// check if blocks are pinned
+//	var blocks []string
+//	var datas []string
+//	list := m.node.Blocks("", -1, "")
+//	for _, b := range list.Items {
+//		blocks = append(blocks, b.Id)
+//		if b.Type == pb.Block_FILES {
+//			datas = append(datas, b.Data)
+//		}
+//	}
+//	missingBlockPins, err := ipfs.NotPinned(c.Ipfs(), blocks)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	if len(missingBlockPins) != 0 {
+//		var strs []string
+//		for _, id := range missingBlockPins {
+//			strs = append(strs, id.Hash().B58String())
+//		}
+//		t.Fatalf("blocks not pinned: %s", strings.Join(strs, ", "))
+//	}
+//
+//	// check if datas are pinned
+//	missingDataPins, err := ipfs.NotPinned(c.Ipfs(), datas)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	if len(missingDataPins) != 0 {
+//		var strs []string
+//		for _, id := range missingDataPins {
+//			strs = append(strs, id.Hash().B58String())
+//		}
+//		t.Fatalf("datas not pinned: %s", strings.Join(strs, ", "))
+//	}
+//
+//	// try unpinning data
+//	if len(datas) > 0 {
+//		dec, err := icid.Decode(datas[0])
+//		if err != nil {
+//			t.Fatal(err)
+//		}
+//		err = ipfs.UnpinCid(c.Ipfs(), dec, true)
+//		if err != nil {
+//			t.Fatal(err)
+//		}
+//		not, err := ipfs.NotPinned(c.Ipfs(), []string{datas[0]})
+//		if err != nil {
+//			t.Fatal(err)
+//		}
+//		if len(not) == 0 || not[0].Hash().B58String() != datas[0] {
+//			t.Fatal("data was not recursively unpinned")
+//		}
+//	}
+//}
+//
+//func TestMobile_TeardownCafes(t *testing.T) {
+//	_ = cafesTestVars.mobile.Stop()
+//	_ = cafesTestVars.cafe.Stop()
+//	cafesTestVars.mobile = nil
+//	cafesTestVars.cafe = nil
+//}
+//
+//func addTestData(m *Mobile) error {
+//	thrd, err := addTestThread(m, &pb.AddThreadConfig{
+//		Key:  ksuid.New().String(),
+//		Name: "test",
+//		Schema: &pb.AddThreadConfig_Schema{
+//			Preset: pb.AddThreadConfig_Schema_MEDIA,
+//		},
+//		Type:    pb.Thread_PRIVATE,
+//		Sharing: pb.Thread_INVITE_ONLY,
+//	})
+//	if err != nil {
+//		return err
+//	}
+//
+//	_, err = m.addFiles([]string{"../mill/testdata/image.jpeg"}, thrd.Id, "hi")
+//	if err != nil {
+//		return err
+//	}
+//	_, err = m.AddMessage(thrd.Id, "hi")
+//	if err != nil {
+//		return err
+//	}
+//	hash, err := m.addFiles([]string{"../mill/testdata/image.png"}, thrd.Id, "hi")
+//	if err != nil {
+//		return err
+//	}
+//	_, err = m.AddComment(hash.B58String(), "nice")
+//	if err != nil {
+//		return err
+//	}
+//	hash, err = m.addFiles([]string{"../mill/testdata/image.jpeg", "../mill/testdata/image.png"}, thrd.Id, "hi")
+//	if err != nil {
+//		return err
+//	}
+//	_, err = m.AddLike(hash.B58String())
+//	if err != nil {
+//		return err
+//	}
+//	_, err = m.AddMessage(thrd.Id, "bye")
+//	if err != nil {
+//		return err
+//	}
+//
+//	return nil
+//}
+//
+///*
+//Handle the request queue.
+//  1. List some requests
+//  2. Write the HTTP request for each
+//  3. Handle them (set to pending, send to cafe)
+//  4. Delete failed (reties not handled here)
+//  5. Set successful to complete
+//*/
+//func flushCafeRequests(limit int) (int, error) {
+//	var count int
+//	res, err := cafesTestVars.mobile.CafeRequests(limit)
+//	if err != nil {
+//		return count, err
+//	}
+//	ids := new(pb.Strings)
+//	err = proto.Unmarshal(res, ids)
+//	if err != nil {
+//		return count, err
+//	}
+//	count = len(ids.Values)
+//
+//	// write the req for each group
+//	reqs := make(map[string]*pb.CafeHTTPRequest)
+//	for _, g := range ids.Values {
+//		res, err = cafesTestVars.mobile.writeCafeRequest(g)
+//		if err != nil {
+//			return count, err
+//		}
+//		req := new(pb.CafeHTTPRequest)
+//		err = proto.Unmarshal(res, req)
+//		if err != nil {
+//			return count, err
+//		}
+//		reqs[g] = req
+//	}
+//
+//	// mark each as pending (new loops for clarity)
+//	for g := range reqs {
+//		err = cafesTestVars.mobile.CafeRequestPending(g)
+//		if err != nil {
+//			return count, err
+//		}
+//	}
+//
+//	// handle each
+//	for g, req := range reqs {
+//		res, err := handleReq(req)
+//		if err != nil {
+//			return count, err
+//		}
+//		if res.StatusCode >= 300 {
+//			reason := fmt.Sprintf("got bad status: %d\n", res.StatusCode)
+//			fmt.Println(reason)
+//			err = cafesTestVars.mobile.FailCafeRequest(g, reason)
+//		} else {
+//			err = cafesTestVars.mobile.CompleteCafeRequest(g)
+//		}
+//		if err != nil {
+//			return count, err
+//		}
+//		res.Body.Close()
+//	}
+//	return count, nil
+//}
+//
+//func flush(batchSize int) error {
+//	count, err := flushCafeRequests(batchSize)
+//	if err != nil {
+//		return err
+//	}
+//	if count > 0 {
+//		return flush(batchSize)
+//	}
+//	return nil
+//}
+//
 func printSyncGroupStatus(status *pb.CafeSyncGroupStatus) {
 	fmt.Println(">>> " + status.Id)
 	fmt.Println(fmt.Sprintf("num. pending: %d", status.NumPending))
@@ -294,19 +301,20 @@ func printSyncGroupStatus(status *pb.CafeSyncGroupStatus) {
 	fmt.Println("<<<")
 }
 
-func handleReq(r *pb.CafeHTTPRequest) (*http.Response, error) {
-	f, err := os.Open(r.Path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	req, err := http.NewRequest(r.Type.String(), r.Url, f)
-	if err != nil {
-		return nil, err
-	}
-	for k, v := range r.Headers {
-		req.Header.Set(k, v)
-	}
-	client := &http.Client{}
-	return client.Do(req)
-}
+//
+//func handleReq(r *pb.CafeHTTPRequest) (*http.Response, error) {
+//	f, err := os.Open(r.Path)
+//	if err != nil {
+//		return nil, err
+//	}
+//	defer f.Close()
+//	req, err := http.NewRequest(r.Type.String(), r.Url, f)
+//	if err != nil {
+//		return nil, err
+//	}
+//	for k, v := range r.Headers {
+//		req.Header.Set(k, v)
+//	}
+//	client := &http.Client{}
+//	return client.Do(req)
+//}

--- a/mobile/cafes_test.go
+++ b/mobile/cafes_test.go
@@ -2,294 +2,287 @@ package mobile
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
 
+	"github.com/golang/protobuf/proto"
+	icid "github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peerstore"
+	"github.com/segmentio/ksuid"
+	"github.com/textileio/go-textile/core"
+	"github.com/textileio/go-textile/ipfs"
 	"github.com/textileio/go-textile/pb"
 )
 
-//
-//import (
-//	"fmt"
-//	"net/http"
-//	"os"
-//	"strings"
-//	"testing"
-//
-//	"github.com/golang/protobuf/proto"
-//	icid "github.com/ipfs/go-cid"
-//	"github.com/libp2p/go-libp2p-core/peerstore"
-//	"github.com/segmentio/ksuid"
-//	"github.com/textileio/go-textile/core"
-//	"github.com/textileio/go-textile/ipfs"
-//	"github.com/textileio/go-textile/pb"
-//)
-//
-//var cafesTestVars = struct {
-//	mobilePath  string
-//	mobile      *Mobile
-//	cafePath    string
-//	cafe        *core.Textile
-//	cafeApiPort string
-//}{
-//	mobilePath:  "./testdata/.textile3",
-//	cafePath:    "./testdata/.textile4",
-//	cafeApiPort: "5000",
-//}
-//
-//func TestMobile_SetupCafes(t *testing.T) {
-//	var err error
-//	cafesTestVars.mobile, err = createAndStartPeer(InitConfig{
-//		RepoPath: cafesTestVars.mobilePath,
-//		Debug:    true,
-//	}, true, &testHandler{}, &testMessenger{})
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	cafesTestVars.cafe, err = core.CreateAndStartPeer(core.InitConfig{
-//		RepoPath:    cafesTestVars.cafePath,
-//		Debug:       true,
-//		SwarmPorts:  "4001",
-//		CafeApiAddr: "0.0.0.0:" + cafesTestVars.cafeApiPort,
-//		CafeURL:     "http://127.0.0.1:" + cafesTestVars.cafeApiPort,
-//		CafeOpen:    true,
-//	}, true)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//}
-//
-//func TestMobile_RegisterCafe(t *testing.T) {
-//	token, err := cafesTestVars.cafe.CreateCafeToken("", true)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	ok, err := cafesTestVars.cafe.ValidateCafeToken(token)
-//	if !ok || err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	// register with cafe
-//	cafeID := cafesTestVars.cafe.Ipfs().Identity
-//	cafesTestVars.mobile.node.Ipfs().Peerstore.AddAddrs(
-//		cafeID, cafesTestVars.cafe.Ipfs().PeerHost.Addrs(), peerstore.PermanentAddrTTL)
-//	err = cafesTestVars.mobile.registerCafe(cafeID.Pretty(), token)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	// add some data
-//	err = addTestData(cafesTestVars.mobile)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//}
-//
-//func TestMobile_HandleCafeRequests(t *testing.T) {
-//	// manually flush until empty
-//	err := flush(10)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	m := cafesTestVars.mobile
-//	c := cafesTestVars.cafe
-//
-//	err = m.node.Datastore().CafeRequests().DeleteCompleteSyncGroups()
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	// ensure all requests have been deleted
-//	cnt := m.node.Datastore().CafeRequests().Count(-1)
-//	if cnt != 0 {
-//		t.Fatalf("expected all requests to be handled, got %d", cnt)
-//	}
-//
-//	// check if blocks are pinned
-//	var blocks []string
-//	var datas []string
-//	list := m.node.Blocks("", -1, "")
-//	for _, b := range list.Items {
-//		blocks = append(blocks, b.Id)
-//		if b.Type == pb.Block_FILES {
-//			datas = append(datas, b.Data)
-//		}
-//	}
-//	missingBlockPins, err := ipfs.NotPinned(c.Ipfs(), blocks)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//	if len(missingBlockPins) != 0 {
-//		var strs []string
-//		for _, id := range missingBlockPins {
-//			strs = append(strs, id.Hash().B58String())
-//		}
-//		t.Fatalf("blocks not pinned: %s", strings.Join(strs, ", "))
-//	}
-//
-//	// check if datas are pinned
-//	missingDataPins, err := ipfs.NotPinned(c.Ipfs(), datas)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//	if len(missingDataPins) != 0 {
-//		var strs []string
-//		for _, id := range missingDataPins {
-//			strs = append(strs, id.Hash().B58String())
-//		}
-//		t.Fatalf("datas not pinned: %s", strings.Join(strs, ", "))
-//	}
-//
-//	// try unpinning data
-//	if len(datas) > 0 {
-//		dec, err := icid.Decode(datas[0])
-//		if err != nil {
-//			t.Fatal(err)
-//		}
-//		err = ipfs.UnpinCid(c.Ipfs(), dec, true)
-//		if err != nil {
-//			t.Fatal(err)
-//		}
-//		not, err := ipfs.NotPinned(c.Ipfs(), []string{datas[0]})
-//		if err != nil {
-//			t.Fatal(err)
-//		}
-//		if len(not) == 0 || not[0].Hash().B58String() != datas[0] {
-//			t.Fatal("data was not recursively unpinned")
-//		}
-//	}
-//}
-//
-//func TestMobile_TeardownCafes(t *testing.T) {
-//	_ = cafesTestVars.mobile.Stop()
-//	_ = cafesTestVars.cafe.Stop()
-//	cafesTestVars.mobile = nil
-//	cafesTestVars.cafe = nil
-//}
-//
-//func addTestData(m *Mobile) error {
-//	thrd, err := addTestThread(m, &pb.AddThreadConfig{
-//		Key:  ksuid.New().String(),
-//		Name: "test",
-//		Schema: &pb.AddThreadConfig_Schema{
-//			Preset: pb.AddThreadConfig_Schema_MEDIA,
-//		},
-//		Type:    pb.Thread_PRIVATE,
-//		Sharing: pb.Thread_INVITE_ONLY,
-//	})
-//	if err != nil {
-//		return err
-//	}
-//
-//	_, err = m.addFiles([]string{"../mill/testdata/image.jpeg"}, thrd.Id, "hi")
-//	if err != nil {
-//		return err
-//	}
-//	_, err = m.AddMessage(thrd.Id, "hi")
-//	if err != nil {
-//		return err
-//	}
-//	hash, err := m.addFiles([]string{"../mill/testdata/image.png"}, thrd.Id, "hi")
-//	if err != nil {
-//		return err
-//	}
-//	_, err = m.AddComment(hash.B58String(), "nice")
-//	if err != nil {
-//		return err
-//	}
-//	hash, err = m.addFiles([]string{"../mill/testdata/image.jpeg", "../mill/testdata/image.png"}, thrd.Id, "hi")
-//	if err != nil {
-//		return err
-//	}
-//	_, err = m.AddLike(hash.B58String())
-//	if err != nil {
-//		return err
-//	}
-//	_, err = m.AddMessage(thrd.Id, "bye")
-//	if err != nil {
-//		return err
-//	}
-//
-//	return nil
-//}
-//
-///*
-//Handle the request queue.
-//  1. List some requests
-//  2. Write the HTTP request for each
-//  3. Handle them (set to pending, send to cafe)
-//  4. Delete failed (reties not handled here)
-//  5. Set successful to complete
-//*/
-//func flushCafeRequests(limit int) (int, error) {
-//	var count int
-//	res, err := cafesTestVars.mobile.CafeRequests(limit)
-//	if err != nil {
-//		return count, err
-//	}
-//	ids := new(pb.Strings)
-//	err = proto.Unmarshal(res, ids)
-//	if err != nil {
-//		return count, err
-//	}
-//	count = len(ids.Values)
-//
-//	// write the req for each group
-//	reqs := make(map[string]*pb.CafeHTTPRequest)
-//	for _, g := range ids.Values {
-//		res, err = cafesTestVars.mobile.writeCafeRequest(g)
-//		if err != nil {
-//			return count, err
-//		}
-//		req := new(pb.CafeHTTPRequest)
-//		err = proto.Unmarshal(res, req)
-//		if err != nil {
-//			return count, err
-//		}
-//		reqs[g] = req
-//	}
-//
-//	// mark each as pending (new loops for clarity)
-//	for g := range reqs {
-//		err = cafesTestVars.mobile.CafeRequestPending(g)
-//		if err != nil {
-//			return count, err
-//		}
-//	}
-//
-//	// handle each
-//	for g, req := range reqs {
-//		res, err := handleReq(req)
-//		if err != nil {
-//			return count, err
-//		}
-//		if res.StatusCode >= 300 {
-//			reason := fmt.Sprintf("got bad status: %d\n", res.StatusCode)
-//			fmt.Println(reason)
-//			err = cafesTestVars.mobile.FailCafeRequest(g, reason)
-//		} else {
-//			err = cafesTestVars.mobile.CompleteCafeRequest(g)
-//		}
-//		if err != nil {
-//			return count, err
-//		}
-//		res.Body.Close()
-//	}
-//	return count, nil
-//}
-//
-//func flush(batchSize int) error {
-//	count, err := flushCafeRequests(batchSize)
-//	if err != nil {
-//		return err
-//	}
-//	if count > 0 {
-//		return flush(batchSize)
-//	}
-//	return nil
-//}
-//
+var cafesTestVars = struct {
+	mobilePath  string
+	mobile      *Mobile
+	cafePath    string
+	cafe        *core.Textile
+	cafeApiPort string
+}{
+	mobilePath:  "./testdata/.textile3",
+	cafePath:    "./testdata/.textile4",
+	cafeApiPort: "5000",
+}
+
+func TestMobile_SetupCafes(t *testing.T) {
+	var err error
+	cafesTestVars.mobile, err = createAndStartPeer(InitConfig{
+		RepoPath: cafesTestVars.mobilePath,
+		Debug:    true,
+	}, true, &testHandler{}, &testMessenger{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cafesTestVars.cafe, err = core.CreateAndStartPeer(core.InitConfig{
+		RepoPath:    cafesTestVars.cafePath,
+		Debug:       true,
+		SwarmPorts:  "4001",
+		CafeApiAddr: "0.0.0.0:" + cafesTestVars.cafeApiPort,
+		CafeURL:     "http://127.0.0.1:" + cafesTestVars.cafeApiPort,
+		CafeOpen:    true,
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMobile_RegisterCafe(t *testing.T) {
+	token, err := cafesTestVars.cafe.CreateCafeToken("", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := cafesTestVars.cafe.ValidateCafeToken(token)
+	if !ok || err != nil {
+		t.Fatal(err)
+	}
+
+	// register with cafe
+	cafeID := cafesTestVars.cafe.Ipfs().Identity
+	cafesTestVars.mobile.node.Ipfs().Peerstore.AddAddrs(
+		cafeID, cafesTestVars.cafe.Ipfs().PeerHost.Addrs(), peerstore.PermanentAddrTTL)
+	err = cafesTestVars.mobile.registerCafe(cafeID.Pretty(), token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add some data
+	err = addTestData(cafesTestVars.mobile)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMobile_HandleCafeRequests(t *testing.T) {
+	// manually flush until empty
+	err := flush(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := cafesTestVars.mobile
+	c := cafesTestVars.cafe
+
+	err = m.node.Datastore().CafeRequests().DeleteCompleteSyncGroups()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ensure all requests have been deleted
+	cnt := m.node.Datastore().CafeRequests().Count(-1)
+	if cnt != 0 {
+		t.Fatalf("expected all requests to be handled, got %d", cnt)
+	}
+
+	// check if blocks are pinned
+	var blocks []string
+	var datas []string
+	list := m.node.Blocks("", -1, "")
+	for _, b := range list.Items {
+		blocks = append(blocks, b.Id)
+		if b.Type == pb.Block_FILES {
+			datas = append(datas, b.Data)
+		}
+	}
+	missingBlockPins, err := ipfs.NotPinned(c.Ipfs(), blocks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missingBlockPins) != 0 {
+		var strs []string
+		for _, id := range missingBlockPins {
+			strs = append(strs, id.Hash().B58String())
+		}
+		t.Fatalf("blocks not pinned: %s", strings.Join(strs, ", "))
+	}
+
+	// check if datas are pinned
+	missingDataPins, err := ipfs.NotPinned(c.Ipfs(), datas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missingDataPins) != 0 {
+		var strs []string
+		for _, id := range missingDataPins {
+			strs = append(strs, id.Hash().B58String())
+		}
+		t.Fatalf("datas not pinned: %s", strings.Join(strs, ", "))
+	}
+
+	// try unpinning data
+	if len(datas) > 0 {
+		dec, err := icid.Decode(datas[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = ipfs.UnpinCid(c.Ipfs(), dec, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		not, err := ipfs.NotPinned(c.Ipfs(), []string{datas[0]})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(not) == 0 || not[0].Hash().B58String() != datas[0] {
+			t.Fatal("data was not recursively unpinned")
+		}
+	}
+}
+
+func TestMobile_TeardownCafes(t *testing.T) {
+	_ = cafesTestVars.mobile.Stop()
+	_ = cafesTestVars.cafe.Stop()
+	cafesTestVars.mobile = nil
+	cafesTestVars.cafe = nil
+}
+
+func addTestData(m *Mobile) error {
+	thrd, err := addTestThread(m, &pb.AddThreadConfig{
+		Key:  ksuid.New().String(),
+		Name: "test",
+		Schema: &pb.AddThreadConfig_Schema{
+			Preset: pb.AddThreadConfig_Schema_MEDIA,
+		},
+		Type:    pb.Thread_PRIVATE,
+		Sharing: pb.Thread_INVITE_ONLY,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = m.addFiles([]string{"../mill/testdata/image.jpeg"}, thrd.Id, "hi")
+	if err != nil {
+		return err
+	}
+	_, err = m.AddMessage(thrd.Id, "hi")
+	if err != nil {
+		return err
+	}
+	hash, err := m.addFiles([]string{"../mill/testdata/image.png"}, thrd.Id, "hi")
+	if err != nil {
+		return err
+	}
+	_, err = m.AddComment(hash.B58String(), "nice")
+	if err != nil {
+		return err
+	}
+	hash, err = m.addFiles([]string{"../mill/testdata/image.jpeg", "../mill/testdata/image.png"}, thrd.Id, "hi")
+	if err != nil {
+		return err
+	}
+	_, err = m.AddLike(hash.B58String())
+	if err != nil {
+		return err
+	}
+	_, err = m.AddMessage(thrd.Id, "bye")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+/*
+Handle the request queue.
+ 1. List some requests
+ 2. Write the HTTP request for each
+ 3. Handle them (set to pending, send to cafe)
+ 4. Delete failed (reties not handled here)
+ 5. Set successful to complete
+*/
+func flushCafeRequests(limit int) (int, error) {
+	var count int
+	res, err := cafesTestVars.mobile.CafeRequests(limit)
+	if err != nil {
+		return count, err
+	}
+	ids := new(pb.Strings)
+	err = proto.Unmarshal(res, ids)
+	if err != nil {
+		return count, err
+	}
+	count = len(ids.Values)
+
+	// write the req for each group
+	reqs := make(map[string]*pb.CafeHTTPRequest)
+	for _, g := range ids.Values {
+		res, err = cafesTestVars.mobile.writeCafeRequest(g)
+		if err != nil {
+			return count, err
+		}
+		req := new(pb.CafeHTTPRequest)
+		err = proto.Unmarshal(res, req)
+		if err != nil {
+			return count, err
+		}
+		reqs[g] = req
+	}
+
+	// mark each as pending (new loops for clarity)
+	for g := range reqs {
+		err = cafesTestVars.mobile.CafeRequestPending(g)
+		if err != nil {
+			return count, err
+		}
+	}
+
+	// handle each
+	for g, req := range reqs {
+		res, err := handleReq(req)
+		if err != nil {
+			return count, err
+		}
+		if res.StatusCode >= 300 {
+			reason := fmt.Sprintf("got bad status: %d\n", res.StatusCode)
+			fmt.Println(reason)
+			err = cafesTestVars.mobile.FailCafeRequest(g, reason)
+		} else {
+			err = cafesTestVars.mobile.CompleteCafeRequest(g)
+		}
+		if err != nil {
+			return count, err
+		}
+		res.Body.Close()
+	}
+	return count, nil
+}
+
+func flush(batchSize int) error {
+	count, err := flushCafeRequests(batchSize)
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return flush(batchSize)
+	}
+	return nil
+}
+
 func printSyncGroupStatus(status *pb.CafeSyncGroupStatus) {
 	fmt.Println(">>> " + status.Id)
 	fmt.Println(fmt.Sprintf("num. pending: %d", status.NumPending))
@@ -301,20 +294,19 @@ func printSyncGroupStatus(status *pb.CafeSyncGroupStatus) {
 	fmt.Println("<<<")
 }
 
-//
-//func handleReq(r *pb.CafeHTTPRequest) (*http.Response, error) {
-//	f, err := os.Open(r.Path)
-//	if err != nil {
-//		return nil, err
-//	}
-//	defer f.Close()
-//	req, err := http.NewRequest(r.Type.String(), r.Url, f)
-//	if err != nil {
-//		return nil, err
-//	}
-//	for k, v := range r.Headers {
-//		req.Header.Set(k, v)
-//	}
-//	client := &http.Client{}
-//	return client.Do(req)
-//}
+func handleReq(r *pb.CafeHTTPRequest) (*http.Response, error) {
+	f, err := os.Open(r.Path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	req, err := http.NewRequest(r.Type.String(), r.Url, f)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range r.Headers {
+		req.Header.Set(k, v)
+	}
+	client := &http.Client{}
+	return client.Do(req)
+}

--- a/mobile/files.go
+++ b/mobile/files.go
@@ -63,9 +63,9 @@ func fileConfigOptions(opts ...fileConfigOption) *fileConfigSettings {
 
 // AddData adds raw data to a thread
 func (m *Mobile) AddData(data string, threadId string, caption string, cb ProtoCallback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		decoded, err := base64.StdEncoding.DecodeString(data)
 		if err != nil {
@@ -85,9 +85,9 @@ func (m *Mobile) AddData(data string, threadId string, caption string, cb ProtoC
 // AddFiles builds a directory from paths (comma separated) and adds it to the thread
 // Note: paths can be file system paths, IPFS hashes, or an existing file hash that may need decryption.
 func (m *Mobile) AddFiles(paths string, threadId string, caption string, cb ProtoCallback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		hash, err := m.addFiles(util.SplitString(paths, ","), threadId, caption)
 		if err != nil {
@@ -101,9 +101,9 @@ func (m *Mobile) AddFiles(paths string, threadId string, caption string, cb Prot
 
 // ShareFiles adds an existing file DAG to a thread via its top level hash (data)
 func (m *Mobile) ShareFiles(data string, threadId string, caption string, cb ProtoCallback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		hash, err := m.shareFiles(data, threadId, caption)
 		if err != nil {
@@ -131,9 +131,9 @@ func (m *Mobile) Files(threadId string, offset string, limit int) ([]byte, error
 
 // FileContent is the async version of fileContent
 func (m *Mobile) FileContent(hash string, cb DataCallback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		cb.Call(m.fileContent(hash))
 	}()
@@ -168,9 +168,9 @@ type img struct {
 
 // ImageFileContentForMinWidth is the async version of imageFileContentForMinWidth
 func (m *Mobile) ImageFileContentForMinWidth(pth string, minWidth int, cb DataCallback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		cb.Call(m.imageFileContentForMinWidth(pth, minWidth))
 	}()

--- a/mobile/files.go
+++ b/mobile/files.go
@@ -63,8 +63,8 @@ func fileConfigOptions(opts ...fileConfigOption) *fileConfigSettings {
 
 // AddData adds raw data to a thread
 func (m *Mobile) AddData(data string, threadId string, caption string, cb ProtoCallback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		decoded, err := base64.StdEncoding.DecodeString(data)
@@ -85,8 +85,8 @@ func (m *Mobile) AddData(data string, threadId string, caption string, cb ProtoC
 // AddFiles builds a directory from paths (comma separated) and adds it to the thread
 // Note: paths can be file system paths, IPFS hashes, or an existing file hash that may need decryption.
 func (m *Mobile) AddFiles(paths string, threadId string, caption string, cb ProtoCallback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		hash, err := m.addFiles(util.SplitString(paths, ","), threadId, caption)
@@ -101,8 +101,8 @@ func (m *Mobile) AddFiles(paths string, threadId string, caption string, cb Prot
 
 // ShareFiles adds an existing file DAG to a thread via its top level hash (data)
 func (m *Mobile) ShareFiles(data string, threadId string, caption string, cb ProtoCallback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		hash, err := m.shareFiles(data, threadId, caption)
@@ -131,8 +131,8 @@ func (m *Mobile) Files(threadId string, offset string, limit int) ([]byte, error
 
 // FileContent is the async version of fileContent
 func (m *Mobile) FileContent(hash string, cb DataCallback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		cb.Call(m.fileContent(hash))
@@ -168,8 +168,8 @@ type img struct {
 
 // ImageFileContentForMinWidth is the async version of imageFileContentForMinWidth
 func (m *Mobile) ImageFileContentForMinWidth(pth string, minWidth int, cb DataCallback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		cb.Call(m.imageFileContentForMinWidth(pth, minWidth))

--- a/mobile/ipfs.go
+++ b/mobile/ipfs.go
@@ -22,8 +22,8 @@ func (m *Mobile) PeerId() (string, error) {
 
 // DataAtPath is the async version of dataAtPath
 func (m *Mobile) DataAtPath(pth string, cb DataCallback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		cb.Call(m.dataAtPath(pth))

--- a/mobile/ipfs.go
+++ b/mobile/ipfs.go
@@ -22,9 +22,9 @@ func (m *Mobile) PeerId() (string, error) {
 
 // DataAtPath is the async version of dataAtPath
 func (m *Mobile) DataAtPath(pth string, cb DataCallback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		cb.Call(m.dataAtPath(pth))
 	}()

--- a/mobile/logs.go
+++ b/mobile/logs.go
@@ -12,5 +12,5 @@ func (m *Mobile) SetLogLevel(level []byte) error {
 		return err
 	}
 
-	return m.node.SetLogLevel(mlevel)
+	return m.node.SetLogLevel(mlevel, false)
 }

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -146,6 +146,9 @@ func NewTextile(config *RunConfig, messenger Messenger) (*Mobile, error) {
 
 // Start the mobile node
 func (m *Mobile) Start() error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
 	if err := m.node.Start(); err != nil {
 		if err == core.ErrStarted {
 			return nil
@@ -209,9 +212,13 @@ func (m *Mobile) Stop() error {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
-	if err := m.node.Stop(); err != nil && err != core.ErrStopped {
+	if err := m.node.Stop(); err != nil {
+		if err == core.ErrStopped {
+			return nil
+		}
 		return err
 	}
+
 	m.notify(pb.MobileEventType_NODE_STOP, nil)
 	return nil
 }

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -92,7 +92,7 @@ type Mobile struct {
 	node      *core.Textile
 	messenger Messenger
 	listener  *broadcast.Listener
-	mux       sync.Mutex
+	lock      sync.Mutex
 }
 
 // InitRepo calls core InitRepo
@@ -146,9 +146,6 @@ func NewTextile(config *RunConfig, messenger Messenger) (*Mobile, error) {
 
 // Start the mobile node
 func (m *Mobile) Start() error {
-	m.mux.Lock()
-	defer m.mux.Unlock()
-
 	if err := m.node.Start(); err != nil {
 		if err == core.ErrStarted {
 			return nil
@@ -209,8 +206,8 @@ func (m *Mobile) Start() error {
 
 // Stop the mobile node
 func (m *Mobile) Stop() error {
-	m.mux.Lock()
-	defer m.mux.Unlock()
+	m.lock.Lock()
+	defer m.lock.Unlock() // ensure the stop event can fire
 
 	if err := m.node.Stop(); err != nil {
 		if err == core.ErrStopped {

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -225,6 +225,16 @@ func (m *Mobile) Online() bool {
 	return m.node.Online()
 }
 
+// FlushLock locks the flush lock
+func (m *Mobile) FlushLock() {
+	m.node.FlushLock()
+}
+
+// FlushUnlock unlocks the flush lock
+func (m *Mobile) FlushUnlock() {
+	m.node.FlushUnlock()
+}
+
 // Version returns common Version
 func (m *Mobile) Version() string {
 	return "v" + common.Version

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -781,6 +781,10 @@ func TestMobile_Stop(t *testing.T) {
 		t.Fatalf("stop mobile node failed: %s", err)
 	}
 	t.Log("---> NODE STOPPED")
+
+	if callbacks != 3 {
+		t.Fatalf("expected 3 callbacks, got %d", callbacks)
+	}
 }
 
 func TestMobile_StopAgain(t *testing.T) {
@@ -792,7 +796,7 @@ func TestMobile_StopAgain(t *testing.T) {
 
 func TestMobile_Teardown(t *testing.T) {
 	testVars.mobile1 = nil
-	//_ = testVars.mobile2.Stop()
+	_ = testVars.mobile2.Stop()
 	testVars.mobile2 = nil
 	_ = os.RemoveAll(testVars.repoPath1)
 	_ = os.RemoveAll(testVars.repoPath2)

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -699,7 +699,7 @@ func TestMobile_AddExternalInvite(t *testing.T) {
 }
 
 func TestMobile_AcceptExternalInvite(t *testing.T) {
-	_, err := testVars.mobile1.AcceptExternalInvite(testVars.invite.Id, testVars.invite.Key)
+	_, err := testVars.mobile2.AcceptExternalInvite(testVars.invite.Id, testVars.invite.Key)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -2,8 +2,10 @@ package mobile
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -99,6 +101,18 @@ func (tm *testMessenger) Notify(event *Event) {
 			return
 		}
 		printSyncGroupStatus(status)
+	}
+}
+
+type testProtoCallback struct{}
+
+var callbacks uint32
+
+func (pc *testProtoCallback) Call(msg []byte, err error) {
+	atomic.AddUint32(&callbacks, 1)
+	fmt.Println(fmt.Sprintf("+++ CALLBACK (num=%d)", callbacks))
+	if err != nil {
+		fmt.Println(err.Error())
 	}
 }
 
@@ -332,7 +346,7 @@ func TestMobile_Messages(t *testing.T) {
 func TestMobile_AddData(t *testing.T) {
 	input := "howdy"
 
-	conf, err := proto.Marshal(&pb.AddThreadConfig{
+	thrd, err := addTestThread(testVars.mobile1, &pb.AddThreadConfig{
 		Key:  ksuid.New().String(),
 		Name: "what",
 		Schema: &pb.AddThreadConfig_Schema{
@@ -342,16 +356,7 @@ func TestMobile_AddData(t *testing.T) {
 		Sharing: pb.Thread_SHARED,
 	})
 	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := testVars.mobile1.AddThread(conf)
-	if err != nil {
 		t.Fatalf("add thread failed: %s", err)
-	}
-	thrd := new(pb.Thread)
-	err = proto.Unmarshal(res, thrd)
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	_, err = testVars.mobile1.addData([]byte(input), thrd.Id, "caption")
@@ -649,7 +654,7 @@ func TestMobile_AddInvite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conf, err := proto.Marshal(&pb.AddThreadConfig{
+	thrd, err := addTestThread(testVars.mobile2, &pb.AddThreadConfig{
 		Key:  ksuid.New().String(),
 		Name: "test2",
 		Schema: &pb.AddThreadConfig_Schema{
@@ -659,16 +664,7 @@ func TestMobile_AddInvite(t *testing.T) {
 		Sharing: pb.Thread_SHARED,
 	})
 	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := testVars.mobile2.AddThread(conf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	thrd := new(pb.Thread)
-	err = proto.Unmarshal([]byte(res), thrd)
-	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("add thread failed: %s", err)
 	}
 
 	contact1, err := testVars.mobile1.Contact(testVars.mobile1.Address())
@@ -760,10 +756,31 @@ func TestMobile_SearchContacts(t *testing.T) {
 }
 
 func TestMobile_Stop(t *testing.T) {
-	err := testVars.mobile1.Stop()
+	thrd, err := addTestThread(testVars.mobile1, &pb.AddThreadConfig{
+		Key:  ksuid.New().String(),
+		Name: "test",
+		Schema: &pb.AddThreadConfig_Schema{
+			Preset: pb.AddThreadConfig_Schema_BLOB,
+		},
+	})
+	if err != nil {
+		t.Fatalf("add thread failed: %s", err)
+	}
+
+	t.Log("---> ADDING DATA")
+	testVars.mobile1.AddData(base64.StdEncoding.EncodeToString([]byte(ksuid.New().String())),
+		thrd.Id, "", &testProtoCallback{})
+	testVars.mobile1.AddData(base64.StdEncoding.EncodeToString([]byte(ksuid.New().String())),
+		thrd.Id, "", &testProtoCallback{})
+	testVars.mobile1.AddData(base64.StdEncoding.EncodeToString([]byte(ksuid.New().String())),
+		thrd.Id, "", &testProtoCallback{})
+
+	t.Log("---> STOPPING NODE")
+	err = testVars.mobile1.Stop()
 	if err != nil {
 		t.Fatalf("stop mobile node failed: %s", err)
 	}
+	t.Log("---> NODE STOPPED")
 }
 
 func TestMobile_StopAgain(t *testing.T) {

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -792,7 +792,7 @@ func TestMobile_StopAgain(t *testing.T) {
 
 func TestMobile_Teardown(t *testing.T) {
 	testVars.mobile1 = nil
-	_ = testVars.mobile2.Stop()
+	//_ = testVars.mobile2.Stop()
 	testVars.mobile2 = nil
 	_ = os.RemoveAll(testVars.repoPath1)
 	_ = os.RemoveAll(testVars.repoPath2)

--- a/mobile/profile.go
+++ b/mobile/profile.go
@@ -58,8 +58,8 @@ func (m *Mobile) Avatar() (string, error) {
 
 // SetAvatar adds the image at pth to the account thread and calls core SetAvatar
 func (m *Mobile) SetAvatar(pth string, cb ProtoCallback) {
+	m.mux.Lock()
 	go func() {
-		m.mux.Lock()
 		defer m.mux.Unlock()
 
 		hash, err := m.setAvatar(pth)

--- a/mobile/profile.go
+++ b/mobile/profile.go
@@ -58,9 +58,9 @@ func (m *Mobile) Avatar() (string, error) {
 
 // SetAvatar adds the image at pth to the account thread and calls core SetAvatar
 func (m *Mobile) SetAvatar(pth string, cb ProtoCallback) {
-	m.mux.Lock()
+	m.node.Lock()
 	go func() {
-		defer m.mux.Unlock()
+		defer m.node.Unlock()
 
 		hash, err := m.setAvatar(pth)
 		if err != nil {

--- a/repo/db/config_test.go
+++ b/repo/db/config_test.go
@@ -20,10 +20,10 @@ func TestMain(m *testing.M) {
 }
 
 func setup() {
-	os.RemoveAll(path.Join("./", "datastore"))
-	os.MkdirAll(path.Join("./", "datastore"), os.ModePerm)
+	_ = os.RemoveAll(path.Join("./", "datastore"))
+	_ = os.MkdirAll(path.Join("./", "datastore"), os.ModePerm)
 	testDB, _ = Create("", "letmein")
-	testDB.config.Init("letmein")
+	_ = testDB.config.Init("letmein")
 
 	w, err := wallet.WalletFromEntropy(128)
 	if err != nil {
@@ -40,7 +40,7 @@ func setup() {
 }
 
 func teardown() {
-	os.RemoveAll(path.Join("./", "datastore"))
+	_ = os.RemoveAll(path.Join("./", "datastore"))
 }
 
 func TestConfigDB_Create(t *testing.T) {

--- a/repo/db/db.go
+++ b/repo/db/db.go
@@ -58,27 +58,27 @@ func Create(repoPath, pin string) (*SQLiteDatastore, error) {
 			return nil, err
 		}
 	}
-	mux := new(sync.Mutex)
+	lock := new(sync.Mutex)
 	return &SQLiteDatastore{
-		config:             NewConfigStore(conn, mux, dbPath),
-		peers:              NewPeerStore(conn, mux),
-		files:              NewFileStore(conn, mux),
-		threads:            NewThreadStore(conn, mux),
-		threadPeers:        NewThreadPeerStore(conn, mux),
-		blocks:             NewBlockStore(conn, mux),
-		blockMessages:      NewBlockMessageStore(conn, mux),
-		invites:            NewInviteStore(conn, mux),
-		notifications:      NewNotificationStore(conn, mux),
-		cafeSessions:       NewCafeSessionStore(conn, mux),
-		cafeRequests:       NewCafeRequestStore(conn, mux),
-		cafeMessages:       NewCafeMessageStore(conn, mux),
-		cafeClientNonces:   NewCafeClientNonceStore(conn, mux),
-		cafeClients:        NewCafeClientStore(conn, mux),
-		cafeTokens:         NewCafeTokenStore(conn, mux),
-		cafeClientThreads:  NewCafeClientThreadStore(conn, mux),
-		cafeClientMessages: NewCafeClientMessageStore(conn, mux),
+		config:             NewConfigStore(conn, lock, dbPath),
+		peers:              NewPeerStore(conn, lock),
+		files:              NewFileStore(conn, lock),
+		threads:            NewThreadStore(conn, lock),
+		threadPeers:        NewThreadPeerStore(conn, lock),
+		blocks:             NewBlockStore(conn, lock),
+		blockMessages:      NewBlockMessageStore(conn, lock),
+		invites:            NewInviteStore(conn, lock),
+		notifications:      NewNotificationStore(conn, lock),
+		cafeSessions:       NewCafeSessionStore(conn, lock),
+		cafeRequests:       NewCafeRequestStore(conn, lock),
+		cafeMessages:       NewCafeMessageStore(conn, lock),
+		cafeClientNonces:   NewCafeClientNonceStore(conn, lock),
+		cafeClients:        NewCafeClientStore(conn, lock),
+		cafeTokens:         NewCafeTokenStore(conn, lock),
+		cafeClientThreads:  NewCafeClientThreadStore(conn, lock),
+		cafeClientMessages: NewCafeClientMessageStore(conn, lock),
 		db:                 conn,
-		lock:               mux,
+		lock:               lock,
 	}, nil
 }
 


### PR DESCRIPTION
Now that we're doing a lot more work in the background of a mobile environment, ensuring that work is completed before honoring a stop request is critical.
- Adds a secondary `sync.Mutex` lock to the core node, which is blocked by the main lock. this ensures that work spawned by current tasks can "skip the line" so to speak and take a lock for themselves before `Stop` is able to
- Moves the mobile lock to use the main core lock, except at `Stop`, ensuring the stop event makes it out
- Fixes an issue where deprecated thread payloads where still being unmarshalled into `nil` bytes
- Adds a color option to the logs, which should help log reading on mobile (no ANSI support)
- Pulls node bootstrapping into textile core, which allows us to properly start a node and not block while it's coming online (previously we'd start two nodes and replace the offline on with the online one when it was ready)

Closes #886
