### PR TITLE
Cafe HTTP API and mobile client

### DIFF
--- a/core/cafe_api.go
+++ b/core/cafe_api.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"net/http"
 	"strings"
 	"sync"
@@ -11,8 +12,11 @@ import (
 	njwt "github.com/dgrijalva/jwt-go"
 	limit "github.com/gin-contrib/size"
 	"github.com/gin-gonic/gin"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/mr-tron/base58/base58"
 	"github.com/textileio/go-textile/jwt"
 	"github.com/textileio/go-textile/pb"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // CafeApiVersion is the cafe api version
@@ -92,6 +96,14 @@ func (c *cafeApi) start() {
 	// v1 routes
 	v1 := router.Group("/api/v1")
 
+	sessions := v1.Group("/sessions")
+	{
+		sessions.GET("/challenge", c.validateChallengeToken, c.getSessionChallenge)
+		sessions.POST("/:pid", c.validateChallengeToken, c.createSession)
+		sessions.POST("/refresh/:pid", c.validateToken, c.refreshSession)
+		sessions.DELETE("/:pid", c.validateToken, c.deleteSession)
+	}
+
 	store := v1.Group("/store", c.validateToken)
 	{
 		store.PUT("", c.store)
@@ -106,6 +118,8 @@ func (c *cafeApi) start() {
 
 	inbox := v1.Group("/inbox")
 	{
+		inbox.GET("/:pid", c.validateToken, c.checkMessages)
+		inbox.DELETE("/:pid", c.validateToken, c.deleteMessages)
 		inbox.POST("/:from/:to", c.deliverMessage)
 	}
 
@@ -157,24 +171,71 @@ func (c *cafeApi) stop() error {
 func (c *cafeApi) validateToken(g *gin.Context) {
 	auth := strings.Split(g.Request.Header.Get("Authorization"), " ")
 	if len(auth) < 2 {
+		log.Warning("missing token")
 		c.abort(g, http.StatusUnauthorized, nil)
 		return
 	}
 	token := auth[1]
 
+	var subject *string
+	pid, err := peer.IDB58Decode(g.Param("pid"))
+	if err == nil {
+		tmp := pid.Pretty()
+		subject = &tmp
+	}
+
 	protocol := string(c.node.cafe.Protocol())
-	claims, err := jwt.Validate(token, c.verifyKeyFunc, false, protocol, nil)
+	claims, err := jwt.Validate(token, c.verifyKeyFunc, false, protocol, subject)
 	if err != nil {
 		switch err {
 		case jwt.ErrNoToken, jwt.ErrExpired:
+			log.Warning("bad or expired token")
 			c.abort(g, http.StatusUnauthorized, nil)
 		case jwt.ErrInvalid:
+			log.Warning("invalid token")
 			c.abort(g, http.StatusForbidden, nil)
 		}
 		return
 	}
 
 	g.Set("from", claims.Subject)
+	g.Set("token", token)
+}
+
+// validateChallengeToken aborts the request if the token is invalid
+func (c *cafeApi) validateChallengeToken(g *gin.Context) {
+	auth := strings.Split(g.Request.Header.Get("Authorization"), " ")
+	if len(auth) < 2 {
+		log.Warning("missing token pass")
+		c.abort(g, http.StatusUnauthorized, nil)
+		return
+	}
+	token := auth[1]
+
+	// does the provided token match?
+	// dev tokens are actually base58(id+token)
+	plainBytes, err := base58.FastBase58Decoding(token)
+	if err != nil || len(plainBytes) < 44 {
+		log.Warning("error decoding token pass")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+
+	encodedToken := c.node.datastore.CafeTokens().Get(hex.EncodeToString(plainBytes[:12]))
+	if encodedToken == nil {
+		log.Warning("token not found")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+
+	err = bcrypt.CompareHashAndPassword(encodedToken.Value, plainBytes[12:])
+	if err != nil {
+		log.Warning("bad token pass")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+
+	g.Set("token", encodedToken.Id)
 }
 
 // verifyKeyFunc returns the correct key for token verification

--- a/core/cafe_api_v1.go
+++ b/core/cafe_api_v1.go
@@ -52,7 +52,7 @@ func (c *cafeApi) getSessionChallenge(g *gin.Context) {
 		return
 	}
 
-	g.JSON(http.StatusOK, gin.H{"challenge": nonce.Value})
+	pbJSON(g, http.StatusOK, nonce)
 }
 
 // POST /sessions/:pid/?account_addr=<address>&challenge=<challenge>&n=<nonce> (header=>token, body=sig)
@@ -107,7 +107,7 @@ func (c *cafeApi) createSession(g *gin.Context) {
 	}
 	sig := buf.Bytes()
 
-	payload := []byte(g.Query("challenge") + g.Query("n"))
+	payload := []byte(g.Query("challenge") + g.Query("nonce"))
 	err = accnt.Verify(payload, sig)
 	if err != nil {
 		log.Warning("verification failed")
@@ -457,7 +457,8 @@ func (c *cafeApi) deleteMessages(g *gin.Context) {
 	// check for more
 	remaining := c.node.datastore.CafeClientMessages().CountByClient(client.Id)
 
-	g.JSON(http.StatusOK, gin.H{"more": remaining > 0})
+	res := &pb.CafeDeleteMessagesAck{More: remaining > 0}
+	pbJSON(g, http.StatusOK, res)
 }
 
 func (c *cafeApi) deliverMessage(g *gin.Context) {

--- a/core/cafe_api_v1.go
+++ b/core/cafe_api_v1.go
@@ -3,19 +3,269 @@ package core
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
+	"time"
 
+	njwt "github.com/dgrijalva/jwt-go"
 	"github.com/gin-gonic/gin"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-ipfs/pin"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/segmentio/ksuid"
 	"github.com/textileio/go-textile/ipfs"
+	"github.com/textileio/go-textile/jwt"
+	"github.com/textileio/go-textile/keypair"
 	"github.com/textileio/go-textile/pb"
 )
+
+// GET /sessions/challenge/?account_addr=<address> (header=>token)
+func (c *cafeApi) getSessionChallenge(g *gin.Context) {
+	addr := g.Query("account_addr")
+	accnt, err := keypair.Parse(addr)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusBadRequest, err)
+		return
+	}
+	if _, err := accnt.Sign([]byte{0x00}); err == nil {
+		// we don't want to handle account seeds, just addresses
+		log.Warning(errInvalidAddress)
+		c.abort(g, http.StatusBadRequest, fmt.Errorf(errInvalidAddress))
+		return
+	}
+
+	// generate a new random nonce
+	nonce := &pb.CafeClientNonce{
+		Value:   ksuid.New().String(),
+		Address: addr,
+		Date:    ptypes.TimestampNow(),
+	}
+	err = c.node.datastore.CafeClientNonces().Add(nonce)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusInternalServerError, err)
+		return
+	}
+
+	g.JSON(http.StatusOK, gin.H{"challenge": nonce.Value})
+}
+
+// POST /sessions/:pid/?account_addr=<address>&challenge=<challenge>&n=<nonce> (header=>token, body=sig)
+func (c *cafeApi) createSession(g *gin.Context) {
+	// are we open?
+	if !c.node.cafe.open {
+		log.Warning("cafe is not open")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+
+	addr := g.Query("account_addr")
+	accnt, err := keypair.Parse(addr)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusBadRequest, err)
+		return
+	}
+
+	pid, err := peer.IDB58Decode(g.Param("pid"))
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusBadRequest, err)
+		return
+	}
+
+	// check nonce
+	snonce := c.node.datastore.CafeClientNonces().Get(g.Query("challenge"))
+	if snonce == nil {
+		log.Warning("challenge not found")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+	if snonce.Address != accnt.Address() {
+		log.Warning("invalid address")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+
+	buf := bodyPool.Get().(*bytes.Buffer)
+	defer func() {
+		buf.Reset()
+		bodyPool.Put(buf)
+	}()
+
+	buf.Grow(bytes.MinRead)
+	_, err = buf.ReadFrom(g.Request.Body)
+	if err != nil && err != io.EOF {
+		log.Warning(err)
+		c.abort(g, http.StatusBadRequest, err)
+		return
+	}
+	sig := buf.Bytes()
+
+	payload := []byte(g.Query("challenge") + g.Query("n"))
+	err = accnt.Verify(payload, sig)
+	if err != nil {
+		log.Warning("verification failed")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+
+	now := ptypes.TimestampNow()
+	client := &pb.CafeClient{
+		Id:      pid.Pretty(),
+		Address: accnt.Address(),
+		Created: now,
+		Seen:    now,
+		Token:   g.GetString("token"),
+	}
+	err = c.node.datastore.CafeClients().Add(client)
+	if err != nil {
+		// check if already exists
+		client = c.node.datastore.CafeClients().Get(pid.Pretty())
+		if client == nil {
+			err = fmt.Errorf("get or create client failed")
+			log.Warning(err)
+			c.abort(g, http.StatusInternalServerError, err)
+			return
+		}
+	}
+
+	session, err := jwt.NewSession(
+		c.node.node.PrivateKey,
+		pid,
+		c.node.cafe.Protocol(),
+		defaultSessionDuration,
+		c.node.cafe.info,
+	)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusInternalServerError, err)
+		return
+	}
+
+	err = c.node.datastore.CafeClientNonces().Delete(snonce.Value)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusInternalServerError, err)
+		return
+	}
+
+	pbJSON(g, http.StatusCreated, session)
+}
+
+// POST /sessions/refresh/:pid (header=>refresh, body=access)
+func (c *cafeApi) refreshSession(g *gin.Context) {
+	// are we _still_ open?
+	if !c.node.cafe.open {
+		log.Warning("cafe is not open")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+
+	buf := bodyPool.Get().(*bytes.Buffer)
+	defer func() {
+		buf.Reset()
+		bodyPool.Put(buf)
+	}()
+
+	buf.Grow(bytes.MinRead)
+	_, err := buf.ReadFrom(g.Request.Body)
+	if err != nil && err != io.EOF {
+		log.Warning(err)
+		c.abort(g, http.StatusBadRequest, err)
+		return
+	}
+
+	// ensure access and refresh are a valid pair
+	access, _ := njwt.Parse(string(buf.Bytes()), c.verifyKeyFunc)
+	if access == nil {
+		log.Warning("error parsing access token")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+	refresh, _ := njwt.Parse(g.GetString("token"), c.verifyKeyFunc)
+	if refresh == nil {
+		log.Warning("error parsing refresh token")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+	accessClaims, err := jwt.ParseClaims(access.Claims)
+	if err != nil {
+		log.Warning("error parsing access claims")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+	refreshClaims, err := jwt.ParseClaims(refresh.Claims)
+	if err != nil {
+		log.Warning("error parsing refresh claims")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+	if refreshClaims.Id[1:] != accessClaims.Id {
+		log.Warning("token id mismatch")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+	if refreshClaims.Subject != accessClaims.Subject {
+		log.Warning("token subject mismatch ")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+
+	// get a new session
+	spid, err := peer.IDB58Decode(accessClaims.Subject)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusInternalServerError, err)
+		return
+	}
+	session, err := jwt.NewSession(
+		c.node.node.PrivateKey,
+		spid,
+		c.node.cafe.Protocol(),
+		defaultSessionDuration,
+		c.node.cafe.info,
+	)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusInternalServerError, err)
+		return
+	}
+
+	pbJSON(g, http.StatusCreated, session)
+}
+
+// DELETE /sessions/:pid (header=>access)
+func (c *cafeApi) deleteSession(g *gin.Context) {
+	pid := g.GetString("from")
+	err := c.node.datastore.CafeClientThreads().DeleteByClient(pid)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusInternalServerError, err)
+		return
+	}
+
+	err = c.node.datastore.CafeClientMessages().DeleteByClient(pid, -1)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusInternalServerError, err)
+		return
+	}
+
+	err = c.node.datastore.CafeClients().Delete(pid)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusInternalServerError, err)
+		return
+	}
+
+	g.Status(http.StatusNoContent)
+}
 
 func (c *cafeApi) store(g *gin.Context) {
 	var err error
@@ -100,6 +350,7 @@ func (c *cafeApi) storeThread(g *gin.Context) {
 
 	client := c.node.datastore.CafeClients().Get(from)
 	if client == nil {
+		log.Warning("client not found")
 		c.abort(g, http.StatusForbidden, nil)
 		return
 	}
@@ -124,6 +375,7 @@ func (c *cafeApi) storeThread(g *gin.Context) {
 		Ciphertext: buf.Bytes(),
 	})
 	if err != nil {
+		log.Warning(err)
 		c.abort(g, http.StatusInternalServerError, err)
 		return
 	}
@@ -139,12 +391,14 @@ func (c *cafeApi) unstoreThread(g *gin.Context) {
 
 	client := c.node.datastore.CafeClients().Get(from)
 	if client == nil {
+		log.Warning("client not found")
 		c.abort(g, http.StatusForbidden, nil)
 		return
 	}
 
 	err := c.node.datastore.CafeClientThreads().Delete(id, client.Id)
 	if err != nil {
+		log.Warning(err)
 		c.abort(g, http.StatusInternalServerError, err)
 		return
 	}
@@ -152,6 +406,58 @@ func (c *cafeApi) unstoreThread(g *gin.Context) {
 	log.Debugf("unstored thread %s", id)
 
 	g.Status(http.StatusNoContent)
+}
+
+func (c *cafeApi) checkMessages(g *gin.Context) {
+	client := c.node.datastore.CafeClients().Get(g.GetString("from"))
+	if client == nil {
+		log.Warning("client not found")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+
+	err := c.node.datastore.CafeClients().UpdateLastSeen(client.Id, time.Now())
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusInternalServerError, err)
+		return
+	}
+
+	res := &pb.CafeMessages{
+		Messages: make([]*pb.CafeMessage, 0),
+	}
+	msgs := c.node.datastore.CafeClientMessages().ListByClient(client.Id, inboxMessagePageSize)
+	for _, msg := range msgs {
+		res.Messages = append(res.Messages, &pb.CafeMessage{
+			Id:   msg.Id,
+			Peer: msg.Peer,
+			Date: msg.Date,
+		})
+	}
+
+	pbJSON(g, http.StatusOK, res)
+}
+
+func (c *cafeApi) deleteMessages(g *gin.Context) {
+	client := c.node.datastore.CafeClients().Get(g.GetString("from"))
+	if client == nil {
+		log.Warning("client not found")
+		c.abort(g, http.StatusForbidden, nil)
+		return
+	}
+
+	// delete the most recent page
+	err := c.node.datastore.CafeClientMessages().DeleteByClient(client.Id, inboxMessagePageSize)
+	if err != nil {
+		log.Warning(err)
+		c.abort(g, http.StatusInternalServerError, err)
+		return
+	}
+
+	// check for more
+	remaining := c.node.datastore.CafeClientMessages().CountByClient(client.Id)
+
+	g.JSON(http.StatusOK, gin.H{"more": remaining > 0})
 }
 
 func (c *cafeApi) deliverMessage(g *gin.Context) {
@@ -238,6 +544,7 @@ func (c *cafeApi) deliverMessage(g *gin.Context) {
 		Date:   ptypes.TimestampNow(),
 	})
 	if err != nil {
+		log.Warning(err)
 		c.abort(g, http.StatusInternalServerError, err)
 		return
 	}
@@ -309,6 +616,7 @@ func (c *cafeApi) search(g *gin.Context) {
 
 			payload, err := proto.Marshal(rpmes)
 			if err != nil {
+				log.Warning(err)
 				c.abort(g, http.StatusInternalServerError, err)
 				return false
 			}

--- a/core/cafe_inbox.go
+++ b/core/cafe_inbox.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/ipfs/go-ipfs/core"
-	peer "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/textileio/go-textile/ipfs"
 	"github.com/textileio/go-textile/pb"
 	"github.com/textileio/go-textile/repo"

--- a/core/cafe_service.go
+++ b/core/cafe_service.go
@@ -272,7 +272,7 @@ func (h *CafeService) CheckMessages(cafeId string) error {
 		}
 	}
 
-	go h.inbox.Flush()
+	h.inbox.Flush()
 
 	// delete them from the remote so that more can be fetched
 	if len(res.Messages) > 0 {
@@ -301,7 +301,7 @@ func (h *CafeService) DeleteMessages(cafeId string) error {
 		return nil
 	}
 
-	// apparently there's more new messages waiting...
+	// apparently there are more new messages waiting...
 	return h.CheckMessages(cafeId)
 }
 

--- a/core/cafes.go
+++ b/core/cafes.go
@@ -28,25 +28,25 @@ func (t *Textile) RegisterCafe(id string, token string) (*pb.CafeSession, error)
 		return nil, err
 	}
 
-	err = t.updatePeerInboxes()
+	err = t.UpdatePeerInboxes()
 	if err != nil {
 		return nil, err
 	}
 
 	// sync all blocks and files target
-	err = t.cafeRequestThreadsContent(session.Id)
+	err = t.CafeRequestThreadsContent(session.Id)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, thrd := range t.loadedThreads {
-		_, err = thrd.annouce(nil)
+		_, err = thrd.Annouce(nil)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	err = t.publishPeer()
+	err = t.PublishPeer()
 	if err != nil {
 		return nil, err
 	}
@@ -72,19 +72,19 @@ func (t *Textile) DeregisterCafe(id string) error {
 		return err
 	}
 
-	err = t.updatePeerInboxes()
+	err = t.UpdatePeerInboxes()
 	if err != nil {
 		return err
 	}
 
 	for _, thrd := range t.loadedThreads {
-		_, err := thrd.annouce(nil)
+		_, err := thrd.Annouce(nil)
 		if err != nil {
 			return err
 		}
 	}
 
-	return t.publishPeer()
+	return t.PublishPeer()
 }
 
 // RefreshCafeSession attempts to refresh a token with a cafe
@@ -111,8 +111,8 @@ func (t *Textile) CafeSessions() *pb.CafeSessionList {
 	return t.datastore.CafeSessions().List()
 }
 
-// cafeRequestThreadContent sync the entire thread conents (blocks and files) to the given cafe
-func (t *Textile) cafeRequestThreadsContent(cafe string) error {
+// CafeRequestThreadContent sync the entire thread conents (blocks and files) to the given cafe
+func (t *Textile) CafeRequestThreadsContent(cafe string) error {
 	for _, thrd := range t.loadedThreads {
 		blocks := t.Blocks("", -1, fmt.Sprintf("threadId='%s'", thrd.Id))
 		for _, b := range blocks.Items {

--- a/core/cafes_test.go
+++ b/core/cafes_test.go
@@ -18,16 +18,13 @@ var cafeVars = struct {
 	nodePath string
 	cafePath string
 
-	cafeApiPort string
-
 	node *Textile
 	cafe *Textile
 
 	token string
 }{
-	nodePath:    "./testdata/.textile3",
-	cafePath:    "./testdata/.textile4",
-	cafeApiPort: "5000",
+	nodePath: "./testdata/.textile3",
+	cafePath: "./testdata/.textile4",
 }
 
 func TestCore_SetupCafes(t *testing.T) {
@@ -44,8 +41,8 @@ func TestCore_SetupCafes(t *testing.T) {
 		RepoPath:    cafeVars.cafePath,
 		Debug:       true,
 		SwarmPorts:  "4001",
-		CafeApiAddr: "0.0.0.0:" + cafeVars.cafeApiPort,
-		CafeURL:     "http://127.0.0.1:" + cafeVars.cafeApiPort,
+		CafeApiAddr: "0.0.0.0:5000",
+		CafeURL:     "http://127.0.0.1:5000",
 		CafeOpen:    true,
 	}, true)
 	if err != nil {

--- a/core/contacts.go
+++ b/core/contacts.go
@@ -14,7 +14,7 @@ import (
 func (t *Textile) AddContact(card *pb.Contact) error {
 	var err error
 	for _, peer := range card.Peers {
-		err = t.addPeer(peer)
+		err = t.AddPeer(peer)
 		if err != nil {
 			return err
 		}

--- a/core/peers.go
+++ b/core/peers.go
@@ -21,8 +21,8 @@ func (t *Textile) PeerUser(id string) *pb.User {
 	}
 }
 
-// addPeer adds or updates a peer
-func (t *Textile) addPeer(peer *pb.Peer) error {
+// AddPeer adds or updates a peer
+func (t *Textile) AddPeer(peer *pb.Peer) error {
 	x := t.datastore.Peers().Get(peer.Id)
 	if x != nil && (peer.Updated == nil || util.ProtoTsIsNewer(x.Updated, peer.Updated)) {
 		return nil
@@ -53,15 +53,15 @@ func (t *Textile) addPeer(peer *pb.Peer) error {
 		return fmt.Errorf("account thread not found")
 	}
 
-	_, err = thrd.annouce(&pb.ThreadAnnounce{Peer: peer})
+	_, err = thrd.Annouce(&pb.ThreadAnnounce{Peer: peer})
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-// publishPeer publishes this peer's info to the cafe network
-func (t *Textile) publishPeer() error {
+// PublishPeer publishes this peer's info to the cafe network
+func (t *Textile) PublishPeer() error {
 	self := t.datastore.Peers().Get(t.node.Identity.Pretty())
 	if self == nil {
 		return nil
@@ -79,8 +79,8 @@ func (t *Textile) publishPeer() error {
 	return nil
 }
 
-// updatePeerInboxes sets own peer inboxes from the current cafe sessions
-func (t *Textile) updatePeerInboxes() error {
+// UpdatePeerInboxes sets own peer inboxes from the current cafe sessions
+func (t *Textile) UpdatePeerInboxes() error {
 	var inboxes []*pb.Cafe
 	for _, session := range t.datastore.CafeSessions().List().Items {
 		inboxes = append(inboxes, session.Cafe)

--- a/core/profile.go
+++ b/core/profile.go
@@ -31,13 +31,13 @@ func (t *Textile) SetName(name string) error {
 	}
 
 	for _, thrd := range t.loadedThreads {
-		_, err = thrd.annouce(nil)
+		_, err = thrd.Annouce(nil)
 		if err != nil {
 			return err
 		}
 	}
 
-	return t.publishPeer()
+	return t.PublishPeer()
 }
 
 // Avatar returns profile avatar
@@ -66,11 +66,11 @@ func (t *Textile) SetAvatar() error {
 	}
 
 	for _, thrd := range t.loadedThreads {
-		_, err = thrd.annouce(nil)
+		_, err = thrd.Annouce(nil)
 		if err != nil {
 			return err
 		}
 	}
 
-	return t.publishPeer()
+	return t.PublishPeer()
 }

--- a/core/thread_announces.go
+++ b/core/thread_announces.go
@@ -9,7 +9,7 @@ import (
 )
 
 // announce creates an outgoing announce block
-func (t *Thread) annouce(msg *pb.ThreadAnnounce) (mh.Multihash, error) {
+func (t *Thread) Annouce(msg *pb.ThreadAnnounce) (mh.Multihash, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 

--- a/core/threads.go
+++ b/core/threads.go
@@ -281,7 +281,7 @@ func (t *Textile) RenameThread(id string, name string) error {
 		return err
 	}
 
-	_, err = thread.annouce(&pb.ThreadAnnounce{Name: trimmed})
+	_, err = thread.Annouce(&pb.ThreadAnnounce{Name: trimmed})
 	return err
 }
 
@@ -553,7 +553,7 @@ func (t *Textile) addAccountThread() error {
 
 	// add existing contacts
 	for _, p := range t.datastore.Peers().List(fmt.Sprintf("address!='%s'", t.account.Address())) {
-		_, err = thread.annouce(&pb.ThreadAnnounce{Peer: p})
+		_, err = thread.Annouce(&pb.ThreadAnnounce{Peer: p})
 		if err != nil {
 			return err
 		}

--- a/mobile/account.go
+++ b/mobile/account.go
@@ -25,6 +25,22 @@ func (m *Mobile) Seed() string {
 	return m.node.Account().Seed()
 }
 
+// Sign calls core Sign
+func (m *Mobile) Sign(input []byte) ([]byte, error) {
+	if !m.node.Started() {
+		return nil, core.ErrStopped
+	}
+	return m.node.Sign(input)
+}
+
+// Verify calls core verify
+func (m *Mobile) Verify(input []byte, sig []byte) error {
+	if !m.node.Started() {
+		return core.ErrStopped
+	}
+	return m.node.Verify(input, sig)
+}
+
 // Encrypt calls core Encrypt
 func (m *Mobile) Encrypt(input []byte) ([]byte, error) {
 	if !m.node.Started() {

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -124,21 +124,25 @@ func MigrateRepo(config *MigrateConfig) error {
 
 // Create a gomobile compatible wrapper around Textile
 func NewTextile(config *RunConfig, messenger Messenger) (*Mobile, error) {
+	mobile := &Mobile{
+		RepoPath:  config.RepoPath,
+		messenger: messenger,
+	}
+
 	node, err := core.NewTextile(core.RunConfig{
 		RepoPath:          config.RepoPath,
 		CafeOutboxHandler: config.CafeOutboxHandler,
+		CheckMessages:     mobile.checkCafeMessages,
 		Debug:             config.Debug,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return &Mobile{
-		RepoPath:  config.RepoPath,
-		node:      node,
-		messenger: messenger,
-		listener:  node.ThreadUpdateListener(),
-	}, nil
+	mobile.node = node
+	mobile.listener = node.ThreadUpdateListener()
+
+	return mobile, nil
 }
 
 // Start the mobile node


### PR DESCRIPTION
This is a pretty big but straightforward change allowing mobile clients to speak HTTP to their cafes nodes. 

Some of these changes are a little cringy—code duplication and such. However, since we're going to remove all this session handling at some point soon-ish, I can (happily) resist the urge to spend too much time on this.