### PR TITLE
Use base repo and account seed in cli

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1224,6 +1224,9 @@ func getRepo(baseRepo string, accountSeed string) (string, error) {
 		if len(files) == 0 {
 			return "", fmt.Errorf("no account repos initialized in: %s", baseRepo)
 		}
+		if len(files) > 1 {
+			return "", fmt.Errorf("there are multiple accounts initialzed in %s, you should specify account-seed", baseRepo)
+		}
 		return path.Join(baseRepo, files[0].Name()), nil
 	}
 	kp, err := keypair.Parse(accountSeed)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -331,7 +331,7 @@ An access token is required to register, and should be obtained separately from 
 	// daemon
 	daemonCmd := appCmd.Command("daemon", "Start a node daemon session")
 	daemonBaseRepo := daemonCmd.Flag("base-repo", "Specify a custom path to the base repo directory").Short('b').String()
-	daemonAccountSeed := daemonCmd.Flag("account-seed", "Specify an existing account seed").Short('a').String()
+	daemonAccountAddress := daemonCmd.Flag("account-address", "Specify an existing account address").Short('a').String()
 	daemonPin := daemonCmd.Flag("pin", "Specify the pin code for datastore encryption (omit no pin code was used during init)").Short('p').String()
 	daemonDocs := daemonCmd.Flag("serve-docs", "Whether to serve the local REST API docs").Short('s').Bool()
 	cmds[daemonCmd.FullCommand()] = func() error {
@@ -339,7 +339,7 @@ An access token is required to register, and should be obtained separately from 
 		if err != nil {
 			return err
 		}
-		repo, err := getRepo(baseRepo, *daemonAccountSeed)
+		repo, err := getRepo(baseRepo, *daemonAccountAddress)
 		if err != nil {
 			return err
 		}
@@ -647,13 +647,13 @@ There are two types of invites, direct account-to-account and external:
 	// migrate
 	migrateCmd := appCmd.Command("migrate", "Migrate the node repository and exit")
 	migrateBaseRepo := migrateCmd.Flag("base-repo", "Specify a custom path to the base repo directory").Short('b').String()
-	migrateAccountSeed := migrateCmd.Flag("account-seed", "Specify an existing account seed").Short('a').String()
+	migrateAccountAddress := migrateCmd.Flag("account-address", "Specify an existing account address").Short('a').String()
 	cmds[migrateCmd.FullCommand()] = func() error {
 		baseRepo, err := getBaseRepo(*migrateBaseRepo)
 		if err != nil {
 			return err
 		}
-		repo, err := getRepo(baseRepo, *migrateAccountSeed)
+		repo, err := getRepo(baseRepo, *migrateAccountAddress)
 		if err != nil {
 			return err
 		}
@@ -1213,10 +1213,10 @@ func getBaseRepo(baseRepo string) (string, error) {
 	return baseRepo, nil
 }
 
-// Get the full repo path for the user, will use the first
-// directory inside baseRepo if accountSeed isn't provided
-func getRepo(baseRepo string, accountSeed string) (string, error) {
-	if len(accountSeed) == 0 {
+// Get the full repo path for the user, will use the single
+// directory inside baseRepo if accountAddress isn't provided
+func getRepo(baseRepo string, accountAddress string) (string, error) {
+	if len(accountAddress) == 0 {
 		files, err := ioutil.ReadDir(baseRepo)
 		if err != nil {
 			return "", err
@@ -1225,19 +1225,11 @@ func getRepo(baseRepo string, accountSeed string) (string, error) {
 			return "", fmt.Errorf("no account repos initialized in: %s", baseRepo)
 		}
 		if len(files) > 1 {
-			return "", fmt.Errorf("there are multiple accounts initialzed in %s, you should specify account-seed", baseRepo)
+			return "", fmt.Errorf("there are multiple accounts initialzed in %s, you need to specify account-address", baseRepo)
 		}
 		return path.Join(baseRepo, files[0].Name()), nil
 	}
-	kp, err := keypair.Parse(accountSeed)
-	if err != nil {
-		return "", fmt.Errorf("parse account seed failed: %s", err)
-	}
-	account, ok := kp.(*keypair.Full)
-	if !ok {
-		return "", keypair.ErrInvalidKey
-	}
-	return path.Join(baseRepo, account.Address()), nil
+	return path.Join(baseRepo, accountAddress), nil
 }
 
 func hideGlobalsFlagsFor(cmds ...*kingpin.CmdClause) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -331,7 +331,7 @@ An access token is required to register, and should be obtained separately from 
 	// daemon
 	daemonCmd := appCmd.Command("daemon", "Start a node daemon session")
 	daemonBaseRepo := daemonCmd.Flag("base-repo", "Specify a custom path to the base repo directory").Short('b').String()
-	daemonAccountSeed := daemonCmd.Flag("account-seed", "Specify an existing acconut seed").Short('a').String()
+	daemonAccountSeed := daemonCmd.Flag("account-seed", "Specify an existing account seed").Short('a').String()
 	daemonPin := daemonCmd.Flag("pin", "Specify the pin code for datastore encryption (omit no pin code was used during init)").Short('p').String()
 	daemonDocs := daemonCmd.Flag("serve-docs", "Whether to serve the local REST API docs").Short('s').Bool()
 	cmds[daemonCmd.FullCommand()] = func() error {
@@ -448,7 +448,7 @@ Stacks may include:
 	cmds[initCmd.FullCommand()] = func() error {
 		kp, err := keypair.Parse(*initAccountSeed)
 		if err != nil {
-			return fmt.Errorf(fmt.Sprintf("parse account seed failed: %s", err))
+			return fmt.Errorf("parse account seed failed: %s", err)
 		}
 
 		account, ok := kp.(*keypair.Full)
@@ -647,7 +647,7 @@ There are two types of invites, direct account-to-account and external:
 	// migrate
 	migrateCmd := appCmd.Command("migrate", "Migrate the node repository and exit")
 	migrateBaseRepo := migrateCmd.Flag("base-repo", "Specify a custom path to the base repo directory").Short('b').String()
-	migrateAccountSeed := migrateCmd.Flag("account-seed", "Specify an existing acconut seed").Short('a').String()
+	migrateAccountSeed := migrateCmd.Flag("account-seed", "Specify an existing account seed").Short('a').String()
 	cmds[migrateCmd.FullCommand()] = func() error {
 		baseRepo, err := getBaseRepo(*migrateBaseRepo)
 		if err != nil {
@@ -1200,13 +1200,13 @@ func getBaseRepo(baseRepo string) (string, error) {
 		// get homedir
 		home, err := homedir.Dir()
 		if err != nil {
-			return "", fmt.Errorf(fmt.Sprintf("get homedir failed: %s", err))
+			return "", fmt.Errorf("get homedir failed: %s", err)
 		}
 
 		// ensure app folder is created
 		appDir := filepath.Join(home, ".textile")
 		if err := os.MkdirAll(appDir, 0755); err != nil {
-			return "", fmt.Errorf(fmt.Sprintf("create repo directory failed: %s", err))
+			return "", fmt.Errorf("create repo directory failed: %s", err)
 		}
 		baseRepo = filepath.Join(appDir, "repo")
 	}
@@ -1231,7 +1231,7 @@ func getRepo(baseRepo string, accountSeed string) (string, error) {
 	}
 	kp, err := keypair.Parse(accountSeed)
 	if err != nil {
-		return "", fmt.Errorf(fmt.Sprintf("parse account seed failed: %s", err))
+		return "", fmt.Errorf("parse account seed failed: %s", err)
 	}
 	account, ok := kp.(*keypair.Full)
 	if !ok {

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -27,7 +27,7 @@ func Daemon(repoPath string, pinCode string, docs bool, debug bool) error {
 		Debug:    debug,
 	})
 	if err != nil {
-		return fmt.Errorf(fmt.Sprintf("create node failed: %s", err))
+		return fmt.Errorf("create node failed: %s", err)
 	}
 
 	gateway.Host = &gateway.Gateway{
@@ -36,7 +36,7 @@ func Daemon(repoPath string, pinCode string, docs bool, debug bool) error {
 
 	err = startNode(docs)
 	if err != nil {
-		return fmt.Errorf(fmt.Sprintf("start node failed: %s", err))
+		return fmt.Errorf("start node failed: %s", err)
 	}
 	printSplash()
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,7 +8,7 @@ import (
 
 func InitCommand(config core.InitConfig) error {
 	if err := core.InitRepo(config); err != nil {
-		return fmt.Errorf(fmt.Sprintf("initialize failed: %s", err))
+		return fmt.Errorf("initialize failed: %s", err)
 	}
 	fmt.Printf("Initialized account with address %s\n", config.Account.Address())
 	return nil

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -12,7 +12,7 @@ func Migrate(repoPath string, pinCode string) error {
 		PinCode:  pinCode,
 		RepoPath: repoPath,
 	}); err != nil {
-		return fmt.Errorf(fmt.Sprintf("migrate repo: %s", err))
+		return fmt.Errorf("migrate repo: %s", err)
 	}
 	fmt.Println("Repo was successfully migrated")
 	return nil

--- a/common/version.go
+++ b/common/version.go
@@ -4,4 +4,4 @@ package common
 var GitCommit, GitBranch, GitState, GitSummary, BuildDate string
 
 // Version is the current application's version literal
-const Version = "0.7.1"
+const Version = "0.7.2"

--- a/core/notifications.go
+++ b/core/notifications.go
@@ -52,7 +52,7 @@ func (t *Textile) AcceptInviteViaNotification(id string) (mh.Multihash, error) {
 		return nil, fmt.Errorf("could not find notification: %s", id)
 	}
 	if notification.Type != pb.Notification_INVITE_RECEIVED {
-		return nil, fmt.Errorf(fmt.Sprintf("notification type is not invite"))
+		return nil, fmt.Errorf("notification type is not invite")
 	}
 
 	hash, err := t.AcceptInvite(notification.Block)
@@ -72,10 +72,10 @@ func (t *Textile) AcceptInviteViaNotification(id string) (mh.Multihash, error) {
 func (t *Textile) IgnoreInviteViaNotification(id string) error {
 	notification := t.datastore.Notifications().Get(id)
 	if notification == nil {
-		return fmt.Errorf(fmt.Sprintf("could not find notification: %s", id))
+		return fmt.Errorf("could not find notification: %s", id)
 	}
 	if notification.Type != pb.Notification_INVITE_RECEIVED {
-		return fmt.Errorf(fmt.Sprintf("notification type is not invite"))
+		return fmt.Errorf("notification type is not invite")
 	}
 
 	err := t.IgnoreInvite(notification.Block)

--- a/strkey/strkey.go
+++ b/strkey/strkey.go
@@ -135,11 +135,11 @@ func checkValidVersionByte(version VersionByte) error {
 func decodeString(src string) ([]byte, error) {
 	raw, err := base58.FastBase58Decoding(src)
 	if err != nil {
-		return nil, fmt.Errorf(fmt.Sprintf("base58 decode failed: %s", err))
+		return nil, fmt.Errorf("base58 decode failed: %s", err)
 	}
 
 	if len(raw) < 3 {
-		return nil, fmt.Errorf(fmt.Sprintf("encoded value is %d bytes; minimum valid length is 3", len(raw)))
+		return nil, fmt.Errorf("encoded value is %d bytes; minimum valid length is 3", len(raw))
 	}
 
 	return raw, nil


### PR DESCRIPTION
Gets the CLI in line with how the programatic API deals with repo locations:

- Removes `repo` flag from `init` and uses `base-repo` instead. It's optional and defaults to `~/.textile/repo`.
- The `daemon` flag now uses `base-repo` instead of `repo` with the same default.
- The `daemon` flag takes an optional `account-seed` flag to specify which account to use. If left out, it defaults to the first sub directory inside `base-repo`
- Same thing for `migrate` flag