### PR TITLE
Expose files by block id in mobile api

### DIFF
--- a/mobile/files.go
+++ b/mobile/files.go
@@ -129,6 +129,20 @@ func (m *Mobile) Files(threadId string, offset string, limit int) ([]byte, error
 	return proto.Marshal(files)
 }
 
+// File calls core File
+func (m *Mobile) File(blockId string) ([]byte, error) {
+	if !m.node.Started() {
+		return nil, core.ErrStopped
+	}
+
+	file, err := m.node.File(blockId)
+	if err != nil {
+		return nil, err
+	}
+
+	return proto.Marshal(file)
+}
+
 // FileContent is the async version of fileContent
 func (m *Mobile) FileContent(hash string, cb DataCallback) {
 	m.node.WaitAdd(1, "Mobile.FileContent")

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -513,6 +513,18 @@ func TestMobile_Files(t *testing.T) {
 	}
 }
 
+func TestMobile_File(t *testing.T) {
+	res, err := testVars.mobile1.File(testVars.filesBlock.Id)
+	if err != nil {
+		t.Fatalf("get thread file failed: %s", err)
+	}
+	files := new(pb.Files)
+	err = proto.Unmarshal(res, files)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMobile_FilesBadThread(t *testing.T) {
 	if _, err := testVars.mobile1.Files("empty", "", -1); err == nil {
 		t.Fatal("get thread files from bad thread should fail")


### PR DESCRIPTION
Popular ask recently by sdk users. Pretty easy, the core method was already there.

Closes #902 