### PR TITLE
mobile: add swarm connect to ipfs api

### DIFF
--- a/mobile/ipfs.go
+++ b/mobile/ipfs.go
@@ -5,6 +5,7 @@ import (
 
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/textileio/go-textile/core"
+	"github.com/textileio/go-textile/ipfs"
 )
 
 // PeerId returns the ipfs peer id
@@ -18,6 +19,20 @@ func (m *Mobile) PeerId() (string, error) {
 		return "", err
 	}
 	return pid.Pretty(), nil
+}
+
+// SwarmConnect opens a new direct connection to a peer using an IPFS multiaddr
+func (m *Mobile) SwarmConnect(address string) (string, error) {
+	if !m.node.Started() {
+		return "", core.ErrStopped
+	}
+
+	results, err := ipfs.SwarmConnect(m.node.Ipfs(), []string{address})
+	if err != nil {
+		return "", err
+	}
+
+	return results[0], nil
 }
 
 // DataAtPath is the async version of dataAtPath


### PR DESCRIPTION
Add `swarm connect` to [Update React Native APIs to match more closely the JS and Rest API](https://github.com/textileio/react-native-sdk/issues/108)

Pretty easy, the core method was already there

Related PR:
[android-textile: add swarm connect to ipfs api](https://github.com/textileio/android-textile/pull/64)
[ios-textile: add swarm connect to ipfs api](https://github.com/textileio/ios-textile/pull/84)
[react-native-sdk: add swarm connect to ipfs ap](https://github.com/textileio/react-native-sdk/pull/159)
