### PR TITLE
Support the old style repo config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ VOLUME $TEXTILE_PATH
 
 # Init opts
 ENV INIT_ARGS \
-  --base-repo=$TEXTILE_PATH \
+  --repo=$TEXTILE_PATH \
   --swarm-ports=4001,8081 \
   --api-bind-addr=0.0.0.0:40600 \
   --gateway-bind-addr=0.0.0.0:5050 \

--- a/Dockerfile.cafe
+++ b/Dockerfile.cafe
@@ -83,7 +83,7 @@ ENV LIBP2P_SWARM_FD_LIMIT 5000
 
 # Init opts
 ENV INIT_ARGS \
-  --base-repo="$TEXTILE_PATH" \
+  --repo="$TEXTILE_PATH" \
   --swarm-ports=4001,8081 \
   --api-bind-addr=0.0.0.0:40600 \
   --gateway-bind-addr=0.0.0.0:5050 \

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -638,7 +638,7 @@ There are two types of invites, direct account-to-account and external:
 
 	// migrate
 	migrateCmd := appCmd.Command("migrate", "Migrate the node repository and exit")
-	migrateRepo := migrateCmd.Flag("repo", "Specify a custom path to the repo directory").Short('b').String()
+	migrateRepo := migrateCmd.Flag("repo", "Specify a custom path to the repo directory").Short('r').String()
 	migrateBaseRepo := migrateCmd.Flag("base-repo", "Specify a custom path to the base repo directory").Short('b').String()
 	migrateAccountAddress := migrateCmd.Flag("account-address", "Specify an existing account address").Short('a').String()
 	cmds[migrateCmd.FullCommand()] = func() error {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -14,14 +14,12 @@ import (
 	"os"
 	"os/signal"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	logging "github.com/ipfs/go-log"
-	"github.com/mitchellh/go-homedir"
 	"github.com/textileio/go-textile/core"
 	"github.com/textileio/go-textile/keypair"
 	"github.com/textileio/go-textile/pb"
@@ -330,16 +328,13 @@ An access token is required to register, and should be obtained separately from 
 
 	// daemon
 	daemonCmd := appCmd.Command("daemon", "Start a node daemon session")
+	daemonRepo := daemonCmd.Flag("repo", "Specify a custom path to the repo directory").Short('r').String()
 	daemonBaseRepo := daemonCmd.Flag("base-repo", "Specify a custom path to the base repo directory").Short('b').String()
 	daemonAccountAddress := daemonCmd.Flag("account-address", "Specify an existing account address").Short('a').String()
 	daemonPin := daemonCmd.Flag("pin", "Specify the pin code for datastore encryption (omit no pin code was used during init)").Short('p').String()
 	daemonDocs := daemonCmd.Flag("serve-docs", "Whether to serve the local REST API docs").Short('s').Bool()
 	cmds[daemonCmd.FullCommand()] = func() error {
-		baseRepo, err := getBaseRepo(*daemonBaseRepo)
-		if err != nil {
-			return err
-		}
-		repo, err := getRepo(baseRepo, *daemonAccountAddress)
+		repo, err := getRepo(*daemonRepo, *daemonBaseRepo, *daemonAccountAddress)
 		if err != nil {
 			return err
 		}
@@ -431,6 +426,7 @@ Stacks may include:
 
 	// init
 	initCmd := appCmd.Command("init", "Configure textile to use the account by creating a local repository to house its data")
+	initRepo := initCmd.Flag("repo", "Specify a custom path to the repo directory").Short('r').String()
 	initBaseRepo := initCmd.Flag("base-repo", "Specify a custom path to the base repo directory").Short('b').String()
 	initAccountSeed := initCmd.Arg("account-seed", "The account seed to use, if you do not have one, refer to: textile wallet --help").Required().String()
 	initPin := initCmd.Flag("pin", "Specify a pin for datastore encryption").Short('p').String()
@@ -456,15 +452,11 @@ Stacks may include:
 			return keypair.ErrInvalidKey
 		}
 
-		baseRepo, err := getBaseRepo(*initBaseRepo)
-		if err != nil {
-			return err
-		}
-
 		config := core.InitConfig{
 			Account:         account,
 			PinCode:         *initPin, // @todo rename to pin
-			BaseRepoPath:    baseRepo,
+			RepoPath:        *initRepo,
+			BaseRepoPath:    *initBaseRepo,
 			SwarmPorts:      *initIpfsSwarmPorts,
 			ApiAddr:         *initApiBindAddr,
 			CafeApiAddr:     *initCafeApiBindAddr,
@@ -646,14 +638,11 @@ There are two types of invites, direct account-to-account and external:
 
 	// migrate
 	migrateCmd := appCmd.Command("migrate", "Migrate the node repository and exit")
+	migrateRepo := migrateCmd.Flag("repo", "Specify a custom path to the repo directory").Short('b').String()
 	migrateBaseRepo := migrateCmd.Flag("base-repo", "Specify a custom path to the base repo directory").Short('b').String()
 	migrateAccountAddress := migrateCmd.Flag("account-address", "Specify an existing account address").Short('a').String()
 	cmds[migrateCmd.FullCommand()] = func() error {
-		baseRepo, err := getBaseRepo(*migrateBaseRepo)
-		if err != nil {
-			return err
-		}
-		repo, err := getRepo(baseRepo, *migrateAccountAddress)
+		repo, err := getRepo(*migrateRepo, *migrateBaseRepo, *migrateAccountAddress)
 		if err != nil {
 			return err
 		}
@@ -1193,49 +1182,20 @@ func output(val interface{}) {
 	fmt.Println(val)
 }
 
-// Get the base repo path for the user, will create it if missing
-// Unless provided, it defaults to ~/.textile/repo
-func getBaseRepo(baseRepo string) (string, error) {
-	if len(baseRepo) == 0 {
-		// get homedir
-		home, err := homedir.Dir()
-		if err != nil {
-			return "", fmt.Errorf("get homedir failed: %s", err)
-		}
-
-		// ensure app folder is created
-		appDir := filepath.Join(home, ".textile")
-		if err := os.MkdirAll(appDir, 0755); err != nil {
-			return "", fmt.Errorf("create repo directory failed: %s", err)
-		}
-		baseRepo = filepath.Join(appDir, "repo")
+// Get the full repo path for the user, will create it if missing
+func getRepo(repo string, baseRepo string, accountAddress string) (string, error) {
+	var finalRepo string
+	if len(repo) > 0 {
+		finalRepo = repo
+	} else if len(baseRepo) > 0 && len(accountAddress) > 0 {
+		finalRepo = path.Join(baseRepo, accountAddress)
+	} else {
+		return "", fmt.Errorf("you must specify --repo or --base-repo and --account-address flags")
 	}
-	return baseRepo, nil
-}
-
-// Get the full repo path for the user, will use the single
-// directory inside baseRepo if accountAddress isn't provided
-func getRepo(baseRepo string, accountAddress string) (string, error) {
-	if len(accountAddress) == 0 {
-		files, err := ioutil.ReadDir(baseRepo)
-		if err != nil {
-			return "", err
-		}
-		if len(files) == 0 {
-			return "", fmt.Errorf("no account repos initialized in: %s", baseRepo)
-		}
-		if len(files) > 1 {
-			for _, file := range files {
-				if !file.IsDir() && file.Name() == "textile" {
-					// This is a pre 0.7.2 repo, not subdir under account path
-					return baseRepo, nil
-				}
-			}
-			return "", fmt.Errorf("there are multiple accounts initialzed in %s, you need to specify account-address", baseRepo)
-		}
-		return path.Join(baseRepo, files[0].Name()), nil
+	if err := os.MkdirAll(finalRepo, 0755); err != nil {
+		return "", fmt.Errorf("create repo directory failed: %s", err)
 	}
-	return path.Join(baseRepo, accountAddress), nil
+	return finalRepo, nil
 }
 
 func hideGlobalsFlagsFor(cmds ...*kingpin.CmdClause) {

--- a/core/config.go
+++ b/core/config.go
@@ -29,7 +29,11 @@ func GetRandomPort() string {
 
 // applyTextileConfigOptions update textile config w/ init options
 func applyTextileConfigOptions(init InitConfig) error {
-	conf, err := config.Read(init.RepoPath())
+	repo, err := init.Repo()
+	if err != nil {
+		return err
+	}
+	conf, err := config.Read(repo)
 	if err != nil {
 		return err
 	}
@@ -71,7 +75,7 @@ func applyTextileConfigOptions(init InitConfig) error {
 	conf.Cafe.Host.NeighborURL = init.CafeNeighborURL
 
 	// write to disk
-	return config.Write(init.RepoPath(), conf)
+	return config.Write(repo, conf)
 }
 
 // applySwarmPortConfigOption sets custom swarm ports (tcp and ws)

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 var vars = struct {
-	initConfig  InitConfig
-	initConfig2 InitConfig
+	initConfig InitConfig
 
 	node   *Textile
 	thread *Thread

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -6,17 +6,18 @@ import (
 	"path"
 	"testing"
 
+	"github.com/textileio/go-textile/keypair"
 	"github.com/textileio/go-textile/util"
 
 	"github.com/segmentio/ksuid"
-	"github.com/textileio/go-textile/keypair"
 	"github.com/textileio/go-textile/mill"
 	"github.com/textileio/go-textile/pb"
 	"github.com/textileio/go-textile/schema/textile"
 )
 
 var vars = struct {
-	initConfig InitConfig
+	initConfig  InitConfig
+	initConfig2 InitConfig
 
 	node   *Textile
 	thread *Thread
@@ -34,16 +35,43 @@ var vars = struct {
 }
 
 func TestRepoPath(t *testing.T) {
-	target := path.Join(vars.initConfig.BaseRepoPath, vars.initConfig.Account.Address())
-	value := vars.initConfig.RepoPath()
+	conf := InitConfig{
+		RepoPath: "path",
+	}
+	value, err := conf.Repo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conf.RepoPath != value {
+		t.Fatalf("repo path incorrect")
+	}
+}
+
+func TestBaseRepoPath(t *testing.T) {
+	conf := InitConfig{
+		BaseRepoPath: "base",
+		Account:      keypair.Random(),
+	}
+	target := path.Join(conf.BaseRepoPath, conf.Account.Address())
+	value, err := conf.Repo()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if target != value {
 		t.Fatalf("repo path incorrect")
 	}
 }
 
 func TestNoRepoExists(t *testing.T) {
-	_ = os.RemoveAll(vars.initConfig.RepoPath())
-	exists := vars.initConfig.RepoExists()
+	repo, err := vars.initConfig.Repo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = os.RemoveAll(repo)
+	exists, err := vars.initConfig.RepoExists()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if exists {
 		t.Fatalf("repo should not exist but it does")
 	}
@@ -56,16 +84,22 @@ func TestInitRepo(t *testing.T) {
 }
 
 func TestRepoExists(t *testing.T) {
-	exists := vars.initConfig.RepoExists()
+	exists, err := vars.initConfig.RepoExists()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !exists {
 		t.Fatalf("repo should exist but it doesn't")
 	}
 }
 
 func TestNewTextile(t *testing.T) {
-	var err error
+	repo, err := vars.initConfig.Repo()
+	if err != nil {
+		t.Fatal(err)
+	}
 	vars.node, err = NewTextile(RunConfig{
-		RepoPath: vars.initConfig.RepoPath(),
+		RepoPath: repo,
 		Debug:    true,
 	})
 	if err != nil {

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -16,14 +16,19 @@ import (
 func CreateAndStartPeer(conf InitConfig, wait bool) (*Textile, error) {
 	conf.Account = keypair.Random()
 
-	_ = os.RemoveAll(conf.RepoPath())
+	repo, err := conf.Repo()
+	if err != nil {
+		return nil, err
+	}
 
-	err := InitRepo(conf)
+	_ = os.RemoveAll(repo)
+
+	err = InitRepo(conf)
 	if err != nil {
 		return nil, err
 	}
 	node, err := NewTextile(RunConfig{
-		RepoPath: conf.RepoPath(),
+		RepoPath: repo,
 		Debug:    conf.Debug,
 	})
 	if err != nil {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -17,16 +17,21 @@ var initConfig = core.InitConfig{
 func TestGateway_Creation(t *testing.T) {
 	initConfig.Account = keypair.Random()
 
-	_ = os.RemoveAll(initConfig.RepoPath())
+	repo, err := initConfig.Repo()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err := core.InitRepo(initConfig)
+	_ = os.RemoveAll(repo)
+
+	err = core.InitRepo(initConfig)
 	if err != nil {
 		t.Errorf("init node failed: %s", err)
 		return
 	}
 
 	node, err := core.NewTextile(core.RunConfig{
-		RepoPath: initConfig.RepoPath(),
+		RepoPath: repo,
 	})
 	if err != nil {
 		t.Errorf("create node failed: %s", err)
@@ -49,5 +54,9 @@ func TestGateway_Stop(t *testing.T) {
 	if err != nil {
 		t.Errorf("stop gateway failed: %s", err)
 	}
-	_ = os.RemoveAll(initConfig.RepoPath())
+	repo, err := initConfig.Repo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = os.RemoveAll(repo)
 }

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -67,6 +67,7 @@ func WalletAccountAt(mnemonic string, index int, passphrase string) ([]byte, err
 // InitConfig is used to setup a textile node
 type InitConfig struct {
 	Seed         string
+	RepoPath     string
 	BaseRepoPath string
 	LogToDisk    bool
 	Debug        bool
@@ -92,13 +93,19 @@ type Mobile struct {
 	listener  *broadcast.Listener
 }
 
-// RepoPath returns the actual location of the configured repo
-func (conf InitConfig) RepoPath() (string, error) {
+// Repo returns the actual location of the configured repo
+func (conf InitConfig) Repo() (string, error) {
 	coreConf, err := conf.coreInitConfig()
 	if err != nil {
 		return "", err
 	}
-	return coreConf.RepoPath(), nil
+
+	repo, err := coreConf.Repo()
+	if err != nil {
+		return "", err
+	}
+
+	return repo, nil
 }
 
 // RepoExists return whether or not the configured repo already exists
@@ -107,7 +114,13 @@ func (conf InitConfig) RepoExists() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return coreConf.RepoExists(), nil
+
+	exists, err := coreConf.RepoExists()
+	if err != nil {
+		return false, err
+	}
+
+	return exists, nil
 }
 
 func (conf InitConfig) account() (*keypair.Full, error) {
@@ -132,6 +145,7 @@ func (conf InitConfig) coreInitConfig() (core.InitConfig, error) {
 	}
 	return core.InitConfig{
 		Account:      accnt,
+		RepoPath:     conf.RepoPath,
 		BaseRepoPath: conf.BaseRepoPath,
 		IsMobile:     true,
 		LogToDisk:    conf.LogToDisk,

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -123,26 +123,16 @@ func (conf InitConfig) RepoExists() (bool, error) {
 	return exists, nil
 }
 
-func (conf InitConfig) account() (*keypair.Full, error) {
-	if conf.Seed == "" {
-		return nil, core.ErrAccountRequired
-	}
-	kp, err := keypair.Parse(conf.Seed)
-	if err != nil {
-		return nil, err
-	}
-	accnt, ok := kp.(*keypair.Full)
-	if !ok {
-		return nil, keypair.ErrInvalidKey
-	}
-	return accnt, nil
-}
-
 func (conf InitConfig) coreInitConfig() (core.InitConfig, error) {
-	accnt, err := conf.account()
-	if err != nil {
-		return core.InitConfig{}, err
+	var accnt *keypair.Full
+	if len(conf.Seed) > 0 {
+		var err error
+		accnt, err = toAccount(conf.Seed)
+		if err != nil {
+			return core.InitConfig{}, err
+		}
 	}
+
 	return core.InitConfig{
 		Account:      accnt,
 		RepoPath:     conf.RepoPath,
@@ -151,6 +141,18 @@ func (conf InitConfig) coreInitConfig() (core.InitConfig, error) {
 		LogToDisk:    conf.LogToDisk,
 		Debug:        conf.Debug,
 	}, nil
+}
+
+func toAccount(seed string) (*keypair.Full, error) {
+	kp, err := keypair.Parse(seed)
+	if err != nil {
+		return nil, err
+	}
+	accnt, ok := kp.(*keypair.Full)
+	if !ok {
+		return nil, keypair.ErrInvalidKey
+	}
+	return accnt, nil
 }
 
 // InitRepo calls core InitRepo

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -163,12 +163,26 @@ func TestGetConfigCoreConfig(t *testing.T) {
 }
 
 func TestRepoPath(t *testing.T) {
+	conf := InitConfig{
+		RepoPath: "path",
+		Seed:     testVars.initConfig1.Seed,
+	}
+	value, err := conf.Repo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conf.RepoPath != value {
+		t.Fatalf("repo path incorrect")
+	}
+}
+
+func TestBaseRepoPath(t *testing.T) {
 	coreConfig, err := testVars.initConfig1.coreInitConfig()
 	if err != nil {
 		t.Fatalf("unable to get core.InitConfig: %s", err)
 	}
 	target := path.Join(coreConfig.BaseRepoPath, coreConfig.Account.Address())
-	value, err := testVars.initConfig1.RepoPath()
+	value, err := testVars.initConfig1.Repo()
 	if err != nil {
 		t.Fatalf("unable to get repo path: %s", err)
 	}
@@ -178,7 +192,7 @@ func TestRepoPath(t *testing.T) {
 }
 
 func TestNoRepoExists(t *testing.T) {
-	repoPath, err := testVars.initConfig1.RepoPath()
+	repoPath, err := testVars.initConfig1.Repo()
 	if err != nil {
 		t.Fatalf("unable to get repo path: %s", err)
 	}
@@ -210,7 +224,7 @@ func TestRepoExists(t *testing.T) {
 }
 
 func TestMigrateRepo(t *testing.T) {
-	repoPath, err := testVars.initConfig1.RepoPath()
+	repoPath, err := testVars.initConfig1.Repo()
 	if err != nil {
 		t.Fatalf("unable to get repo path: %s", err)
 	}
@@ -223,7 +237,7 @@ func TestMigrateRepo(t *testing.T) {
 }
 
 func TestNewTextile(t *testing.T) {
-	repoPath, err := testVars.initConfig1.RepoPath()
+	repoPath, err := testVars.initConfig1.Repo()
 	if err != nil {
 		t.Fatalf("unable to get repo path: %s", err)
 	}
@@ -238,7 +252,7 @@ func TestNewTextile(t *testing.T) {
 }
 
 func TestNewTextileAgain(t *testing.T) {
-	repoPath, err := testVars.initConfig1.RepoPath()
+	repoPath, err := testVars.initConfig1.Repo()
 	if err != nil {
 		t.Fatalf("unable to get repo path: %s", err)
 	}
@@ -879,11 +893,11 @@ func TestMobile_Teardown(t *testing.T) {
 	testVars.mobile1 = nil
 	_ = testVars.mobile2.stop()
 	testVars.mobile2 = nil
-	repoPath1, err := testVars.initConfig1.RepoPath()
+	repoPath1, err := testVars.initConfig1.Repo()
 	if err != nil {
 		t.Fatalf("unable to get repo path 1: %s", err)
 	}
-	repoPath2, err := testVars.initConfig1.RepoPath()
+	repoPath2, err := testVars.initConfig1.Repo()
 	if err != nil {
 		t.Fatalf("unable to get repo path 2: %s", err)
 	}

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -142,16 +142,6 @@ func TestWalletAccountAt(t *testing.T) {
 	testVars.initConfig1.Seed = accnt.Seed
 }
 
-func TestGetConfigAccount(t *testing.T) {
-	accnt, err := testVars.initConfig1.account()
-	if err != nil {
-		t.Fatalf("unable to get account: %s", err)
-	}
-	if accnt.Seed() != testVars.initConfig1.Seed {
-		t.Fatalf("config seed and account seed don't match")
-	}
-}
-
 func TestGetConfigCoreConfig(t *testing.T) {
 	conf, err := testVars.initConfig1.coreInitConfig()
 	if err != nil {
@@ -165,7 +155,6 @@ func TestGetConfigCoreConfig(t *testing.T) {
 func TestRepoPath(t *testing.T) {
 	conf := InitConfig{
 		RepoPath: "path",
-		Seed:     testVars.initConfig1.Seed,
 	}
 	value, err := conf.Repo()
 	if err != nil {

--- a/mobile/test_utils.go
+++ b/mobile/test_utils.go
@@ -28,7 +28,7 @@ func createAndStartPeer(conf InitConfig, wait bool, handler core.CafeOutboxHandl
 	}
 	conf.Seed = accnt.Seed
 
-	repoPath, err := conf.RepoPath()
+	repoPath, err := conf.Repo()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Along side new account-scoped repo directories, we can let the docker files and library users continue to specify `repo` if they chose. This will buy us some time to get the account scoped repos api correct and complete.

The only change is there is no default behavior if you don't specify repo path OR base repo path and account... you have to supply one or the other. This is to avoid likely errors that will in happen in practice if there is a default behavior. 