### PR TITLE
Additional RepoExists methods

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -4,4 +4,4 @@ package common
 var GitCommit, GitBranch, GitState, GitSummary, BuildDate string
 
 // Version is the current application's version literal
-const Version = "0.7.3"
+const Version = "0.7.4"

--- a/core/core.go
+++ b/core/core.go
@@ -139,7 +139,17 @@ func (conf InitConfig) RepoExists() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return fsrepo.IsInitialized(repoPath), nil
+	return RepoExists(repoPath), nil
+}
+
+// RepoExists return whether or not the repo at repoPath exists
+func RepoExists(repoPath string) bool {
+	return fsrepo.IsInitialized(repoPath)
+}
+
+// AccountRepoExists return whether or not the repo at repoPath exists
+func AccountRepoExists(baseRepoPath string, accountAddress string) bool {
+	return fsrepo.IsInitialized(path.Join(baseRepoPath, accountAddress))
 }
 
 // InitRepo initializes a new node repo

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -72,7 +72,15 @@ func TestNoRepoExists(t *testing.T) {
 		t.Fatal(err)
 	}
 	if exists {
-		t.Fatalf("repo should not exist but it does")
+		t.Fatalf("repo should not exist via InitConfig.RepoExists, but it does")
+	}
+	exists = RepoExists(repo)
+	if exists {
+		t.Fatalf("repo should not exist via RepoExists, but it does")
+	}
+	exists = AccountRepoExists(vars.initConfig.BaseRepoPath, vars.initConfig.Account.Address())
+	if exists {
+		t.Fatalf("repo should not exist via AccountRepoExists, but it does")
 	}
 }
 
@@ -83,12 +91,24 @@ func TestInitRepo(t *testing.T) {
 }
 
 func TestRepoExists(t *testing.T) {
+	repo, err := vars.initConfig.Repo()
+	if err != nil {
+		t.Fatal(err)
+	}
 	exists, err := vars.initConfig.RepoExists()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !exists {
-		t.Fatalf("repo should exist but it doesn't")
+		t.Fatalf("repo should exist via InitConfig.RepoExists, but it doesn't")
+	}
+	exists = RepoExists(repo)
+	if !exists {
+		t.Fatalf("repo should exist via RepoExists, but it doesn't")
+	}
+	exists = AccountRepoExists(vars.initConfig.BaseRepoPath, vars.initConfig.Account.Address())
+	if !exists {
+		t.Fatalf("repo should exist via AccountRepoExists, but it doesn't")
 	}
 }
 

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -123,6 +123,16 @@ func (conf InitConfig) RepoExists() (bool, error) {
 	return exists, nil
 }
 
+// RepoExists return whether or not the repo at repoPath exists
+func RepoExists(repoPath string) bool {
+	return core.RepoExists(repoPath)
+}
+
+// AccountRepoExists return whether or not the repo at repoPath exists
+func AccountRepoExists(baseRepoPath string, accountAddress string) bool {
+	return core.AccountRepoExists(baseRepoPath, accountAddress)
+}
+
 func (conf InitConfig) coreInitConfig() (core.InitConfig, error) {
 	var accnt *keypair.Full
 	if len(conf.Seed) > 0 {

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -21,6 +21,8 @@ var testVars = struct {
 	initConfig1 InitConfig
 	initConfig2 InitConfig
 
+	account1 *pb.MobileWalletAccount
+
 	recovery string
 
 	mobile1 *Mobile
@@ -139,6 +141,7 @@ func TestWalletAccountAt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	testVars.account1 = accnt
 	testVars.initConfig1.Seed = accnt.Seed
 }
 
@@ -191,7 +194,15 @@ func TestNoRepoExists(t *testing.T) {
 		t.Fatalf("unable to check if repo exists: %s", err)
 	}
 	if exists {
-		t.Fatalf("repo should not exist but it does")
+		t.Fatalf("repo should not exist via InitConfig.RepoExists, but it does")
+	}
+	exists = RepoExists(repoPath)
+	if exists {
+		t.Fatalf("repo should not exist via RepoExists, but it does")
+	}
+	exists = AccountRepoExists(testVars.initConfig1.BaseRepoPath, testVars.account1.GetAddress())
+	if exists {
+		t.Fatalf("repo should not exist via AccountRepoExists, but it does")
 	}
 }
 
@@ -203,12 +214,24 @@ func TestInitRepo(t *testing.T) {
 }
 
 func TestRepoExists(t *testing.T) {
+	repoPath, err := testVars.initConfig1.Repo()
+	if err != nil {
+		t.Fatalf("unable to get repo path: %s", err)
+	}
 	exists, err := testVars.initConfig1.RepoExists()
 	if err != nil {
 		t.Fatalf("unable to check if repo exists: %s", err)
 	}
 	if !exists {
-		t.Fatalf("repo should exist but it doesn't")
+		t.Fatalf("repo should exist via InitConfig.RepoExists, but it doesn't")
+	}
+	exists = RepoExists(repoPath)
+	if !exists {
+		t.Fatalf("repo should exist via RepoExists, but it doesn't")
+	}
+	exists = AccountRepoExists(testVars.initConfig1.BaseRepoPath, testVars.account1.GetAddress())
+	if !exists {
+		t.Fatalf("repo should exist via AccountRepoExists, but it doesn't")
 	}
 }
 


### PR DESCRIPTION
Needed to provide simple top level methods for checking if a repo exists. The idea being that you shouldn't need to construct a full `InitConfig` to be able to check if a repo exists. This just adds more options.

Shall we release?