### PR TITLE
docker: update circleci and go-textile images to Go 1.13

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5
+FROM golang:1.13.1
 
 # replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
 
   unit-test:
     docker:
-      - image: textile/builder:1.12.5
+      - image: textile/builder:1.13.1
     steps:
       - *checkout-linux
       - restore_cache:
@@ -45,7 +45,7 @@ jobs:
 
   build-cli-linux:
     docker:
-      - image: textile/builder:1.12.5
+      - image: textile/builder:1.13.1
     steps:
       - *checkout-linux
       - restore_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch
+FROM golang:1.13.1-stretch
 MAINTAINER Sander Pick <sander@textile.io>
 
 # This is (in large part) copied (with love) from

--- a/Dockerfile.cafe
+++ b/Dockerfile.cafe
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch
+FROM golang:1.13.1-stretch
 MAINTAINER Sander Pick <sander@textile.io>
 
 # This is (in large part) copied (with love) from


### PR DESCRIPTION
Fixes #918 
Fixes #920

Update docker-images to use `golang:1.13.1` for [`builder:1.13.1`](https://cloud.docker.com/u/textile/repository/docker/textile/builder/tags) and `go-textile(+cafe)` . 

Also update `.circleci/config.yaml` accordingly.