### PR TITLE
build: adds env var to build CGO_ENABLED=0 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             fi
             DATE=$(date --iso-8601=seconds)
             FLAGS="-X github.com/textileio/go-textile/common.GitSummary=${SUMMARY} -X github.com/textileio/go-textile/common.BuildDate=${DATE} -X github.com/textileio/go-textile/common.GitCommit=${COMMIT} -X github.com/textileio/go-textile/common.GitBranch=${CIRCLE_BRANCH} -X github.com/textileio/go-textile/common.GitState=clean"
-            gox -ldflags="-w $FLAGS" -osarch="linux/amd64 linux/386 linux/arm" -output="{{.OS}}-{{.Arch}}" ./cmd/textile
+            env CGO_ENABLED=0 gox -ldflags="-w $FLAGS" -osarch="linux/amd64 linux/386 linux/arm" -output="{{.OS}}-{{.Arch}}" ./cmd/textile
       - run:
           name: collect artifacts
           command: |

--- a/common/version.go
+++ b/common/version.go
@@ -4,4 +4,4 @@ package common
 var GitCommit, GitBranch, GitState, GitSummary, BuildDate string
 
 // Version is the current application's version literal
-const Version = "0.7.4"
+const Version = "0.7.5"


### PR DESCRIPTION
ensures that the build of the CI machine is also statically linked