### PR TITLE
ipfs: add raw pubsub pub and sub to api and cmd and mobile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ protos:
 .PHONY: docs
 docs:
 	go get github.com/swaggo/swag/cmd/swag
-	swag init -g core/api.go
+	swag init -g api/api.go -o api/docs
 	npm i -g swagger-markdown
-	swagger-markdown -i docs/swagger.yaml -o docs/swagger.md
+	swagger-markdown -i api/docs/swagger.yaml -o api/docs/swagger.md
 
 docker:
 	$(eval VERSION := $$(shell ggrep -oP 'const Version = "\K[^"]+' common/version.go))

--- a/api/api.go
+++ b/api/api.go
@@ -325,6 +325,12 @@ func (a *Api) Run() {
 				swarm.POST("/connect", a.ipfsSwarmConnect)
 				swarm.GET("/peers", a.ipfsSwarmPeers)
 			}
+
+			pubsub := ipfs.Group("/pubsub")
+			{
+				pubsub.POST("/pub/:topic", a.ipfsPubsubPub)
+				pubsub.GET("/sub/:topic", a.ipfsPubsubSub)
+			}
 		}
 
 		bots := v0.Group("/bots")

--- a/api/api_logs.go
+++ b/api/api_logs.go
@@ -19,7 +19,7 @@ type SubsystemInfo map[string]string
 // @Produce application/json
 // @Param subsystem path string false "subsystem logging identifier (omit for all)"
 // @Param X-Textile-Opts header string false "level: Log-level (one of: debug, info, warning, error, critical, or "" to get current), tex-only: Whether to list/change only Textile subsystems, or all available subsystems" default(level=,tex-only="false")
-// @Success 200 {object} core.SubsystemInfo "subsystems"
+// @Success 200 {object} api.SubsystemInfo "subsystems"
 // @Failure 400 {string} string "Bad Request"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /logs/{subsystem} [post]

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -599,6 +599,24 @@ There are two types of invites, direct account-to-account and external:
 		return IpfsCat(*ipfsCatHash, *ipfsCatKey)
 	}
 
+	// ipfs pubsub
+	ipfsPubsubCmd := ipfsCmd.Command("pubsub", "Provides access to IPFS pubsub commands")
+
+	// ipfs pubsub pub
+	ipfsPubsubPubCmd := ipfsPubsubCmd.Command("pub", "Publish a message to a given pubsub topic")
+	ipfsPubsubPubTopic := ipfsPubsubPubCmd.Arg("topic", "Topic to publish to").Required().String()
+	ipfsPubsubPubData := ipfsPubsubPubCmd.Arg("data", "Payload of message to publish").Required().String()
+	cmds[ipfsPubsubPubCmd.FullCommand()] = func() error {
+		return IpfsPubsubPub(*ipfsPubsubPubTopic, *ipfsPubsubPubData)
+	}
+
+	// ipfs pubsub sub
+	ipfsPubsubSubCmd := ipfsPubsubCmd.Command("sub", "Subscribe to messages on a given topic")
+	ipfsPubsubSubTopic := ipfsPubsubSubCmd.Arg("topic", "String name of topic to subscribe to").Required().String()
+	cmds[ipfsPubsubSubCmd.FullCommand()] = func() error {
+		return IpfsPubsubSubCommand(*ipfsPubsubSubTopic)
+	}
+
 	// ================================
 
 	// like

--- a/cmd/ipfs.go
+++ b/cmd/ipfs.go
@@ -1,8 +1,16 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"strconv"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/textileio/go-textile/pb"
+	"github.com/textileio/go-textile/util"
 )
 
 func IpfsPeer() error {
@@ -45,4 +53,77 @@ func IpfsCat(hash string, key string) error {
 	return executeBlobCmd(http.MethodGet, "ipfs/cat/"+hash, params{
 		opts: map[string]string{"key": key},
 	})
+}
+
+func IpfsPubsubPub(topic string, data string) error {
+	res, err := executeStringCmd(http.MethodPost, "ipfs/pubsub/pub/"+topic, params{
+		payload: strings.NewReader(data),
+	})
+	if err != nil {
+		return err
+	}
+	output(res)
+	return nil
+}
+
+func IpfsPubsubSubCommand(topic string) error {
+	updates, err := IpfsPubsubSub(topic)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case update, ok := <-updates:
+			if !ok {
+				return nil
+			}
+
+			strings := new(pb.Strings)
+			err = proto.Unmarshal(update.Data.Value.Value, strings)
+			if err != nil {
+				return err
+			}
+			fmt.Printf(strings.GetValues()[0])
+		}
+	}
+}
+
+func IpfsPubsubSub(topic string) (<-chan *pb.MobileQueryEvent, error) {
+	updates := make(chan *pb.MobileQueryEvent, 10)
+	go func() {
+		defer close(updates)
+
+		res, cancel, err := request(http.MethodGet, "ipfs/pubsub/sub/"+topic, params{})
+		if err != nil {
+			output(err.Error())
+			return
+		}
+		defer res.Body.Close()
+		defer cancel()
+
+		if res.StatusCode >= 400 {
+			body, err := util.UnmarshalString(res.Body)
+			if err != nil {
+				output(err.Error())
+			} else {
+				output(body)
+			}
+			return
+		}
+
+		decoder := json.NewDecoder(res.Body)
+		for decoder.More() {
+			var update pb.MobileQueryEvent
+			if err := pbUnmarshaler.UnmarshalNext(decoder, &update); err == io.EOF {
+				return
+			} else if err != nil {
+				output(err.Error())
+				return
+			}
+			updates <- &update
+		}
+	}()
+
+	return updates, nil
 }

--- a/mobile/ipfs.go
+++ b/mobile/ipfs.go
@@ -2,10 +2,17 @@ package mobile
 
 import (
 	"bytes"
+	"fmt"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
 	ipld "github.com/ipfs/go-ipld-format"
+	iface "github.com/ipfs/interface-go-ipfs-core"
+	"github.com/segmentio/ksuid"
+	"github.com/textileio/go-textile/broadcast"
 	"github.com/textileio/go-textile/core"
 	"github.com/textileio/go-textile/ipfs"
+	"github.com/textileio/go-textile/pb"
 )
 
 // PeerId returns the ipfs peer id
@@ -64,4 +71,145 @@ func (m *Mobile) dataAtPath(pth string) ([]byte, string, error) {
 	}
 
 	return data, media, nil
+}
+
+// IpfsPubsubPub publishes a message to a given pubsub topic
+func (m *Mobile) IpfsPubsubPub(topic string, data string) error {
+	if !m.node.Started() {
+		return core.ErrStopped
+	}
+
+	payload := []byte(data)
+	err := ipfs.Publish(m.node.Ipfs(), topic, payload)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CancelIpfsPubsubSub is used to cancel the request
+func (m *Mobile) CancelIpfsPubsubSub(queryId string) {
+	index := -1
+	for i, handle := range ipfsPubsubSubHandles {
+		if (queryId == handle.Id) {
+			handle.cancel.Close()
+			handle.done()
+			index = i
+			break
+		}
+	}
+	if index != -1 {
+		ipfsPubsubSubHandles = append(ipfsPubsubSubHandles[:index], ipfsPubsubSubHandles[index + 1:]...)
+	}
+}
+
+var ipfsPubsubSubHandles = []*SearchHandle{}
+
+// IpfsPubsubSub Subscribes to messages on a given topic
+func (m *Mobile) IpfsPubsubSub(topic string) (string, error) {
+	if !m.node.Started() {
+		return "", core.ErrStopped
+	}
+
+	msgs := make(chan iface.PubSubMessage, 10)
+	ctx := m.node.Ipfs().Context()
+	id := ksuid.New().String()
+	go func() {
+		if err := ipfs.Subscribe(m.node.Ipfs(), ctx, topic, true, msgs); err != nil {
+			close(msgs)
+			m.notify(pb.MobileEventType_QUERY_RESPONSE, &pb.MobileQueryEvent{
+				Id:   id,
+				Type: pb.MobileQueryEvent_ERROR,
+				Error: &pb.Error{
+					Code:    500,
+					Message: err.Error(),
+				},
+			})
+			log.Errorf("ipfs pubsub sub stopped with error: %s", err.Error())
+			return
+		}
+	}()
+	log.Infof("ipfs pubsub sub started for %s", topic)
+
+	var done bool
+	doneFn := func() {
+		if done {
+			return
+		}
+		done = true
+		m.notify(pb.MobileEventType_QUERY_RESPONSE, &pb.MobileQueryEvent{
+			Id:   id,
+			Type: pb.MobileQueryEvent_DONE,
+		})
+	}
+	cancel := broadcast.NewBroadcaster(0)
+	ipfsPubsubSubHandles = append(ipfsPubsubSubHandles, &SearchHandle{
+		Id:     id,
+		cancel: cancel,
+		done:   doneFn,
+	})
+	cancelCh := cancel.Listen().Ch
+
+	go func() {
+		for {
+			select {
+			case <-cancelCh:
+				log.Infof("ipfs pubsub sub shutdown for %s", topic)
+				return
+			case msg, ok := <-msgs:
+				if !ok {
+					index := -1
+					for i, handle := range ipfsPubsubSubHandles {
+						if (id == handle.Id) {
+							index = i
+							break
+						}
+					}
+					if index != -1 {
+						ipfsPubsubSubHandles = append(ipfsPubsubSubHandles[:index], ipfsPubsubSubHandles[index + 1:]...)
+					}
+
+					doneFn()
+					log.Infof("ipfs pubsub sub shutdown for %s", topic)
+					return
+				}
+
+				mPeer := msg.From()
+				if mPeer.Pretty() == m.node.Ipfs().Identity.Pretty() {
+					break
+				}
+
+				value, err := proto.Marshal(&pb.Strings{
+					Values: []string{string(msg.Data())},
+				})
+				if err != nil {
+					m.notify(pb.MobileEventType_QUERY_RESPONSE, &pb.MobileQueryEvent{
+						Id:   id,
+						Type: pb.MobileQueryEvent_ERROR,
+						Error: &pb.Error{
+							Code:    500,
+							Message: err.Error(),
+						},
+					})
+					break
+				}
+
+				res := &pb.QueryResult{
+					Id:    fmt.Sprintf("%x", msg.Seq()),
+					Value: &any.Any{
+						TypeUrl: "/Strings",
+						Value:   value,
+					},
+				}
+				m.notify(pb.MobileEventType_QUERY_RESPONSE, &pb.MobileQueryEvent{
+					Id:   id,
+					Type: pb.MobileQueryEvent_DATA,
+					Data: res,
+				})
+			}
+		}
+	}()
+
+	return id, nil
 }


### PR DESCRIPTION
Add raw ipfs pubsub pub and sub to [Expose simple p2p direct message API](https://github.com/textileio/go-textile/issues/885)

Additionally: fix `make docs` since "api as sub mod" 6d9f183

For easy PR review, there is no latest docs in this PR

ps: Also add some `textile.events` in `js-http-client` for consistency with `react-native-sdk` when use ipfs pubsub pub and sub, see [docs: add raw ipfs pubsub pub and sub from go-textile v0.7.6](https://github.com/textileio/docs/pull/115)

Related PR:
[js-http-client: add raw ipfs pubsub pub and sub from go-textile v0.7.6](https://github.com/textileio/js-http-client/pull/137)
[android-textile: add raw ipfs pubsub pub and sub from go-textile v0.7.6](https://github.com/textileio/android-textile/pull/66)
[ios-textile: add raw ipfs pubsub pub and sub from go-textile v0.7.6](https://github.com/textileio/ios-textile/pull/86)
[react-native-sdk: add raw ipfs pubsub pub and sub from android 2.0.10 and ios 2.0.12 and go-textile v0.7.6](https://github.com/textileio/react-native-sdk/pull/161)
