### PR TITLE
gateway: remove path suffix handling

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -4,4 +4,4 @@ package common
 var GitCommit, GitBranch, GitState, GitSummary, BuildDate string
 
 // Version is the current application's version literal
-const Version = "0.7.6"
+const Version = "0.7.8"

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -27,7 +27,6 @@ import (
 	"github.com/textileio/go-textile/gateway/templates"
 	"github.com/textileio/go-textile/ipfs"
 	"github.com/textileio/go-textile/pb"
-	"github.com/textileio/go-textile/util"
 )
 
 var log = logging.Logger("tex-gateway")
@@ -82,6 +81,7 @@ func (g *Gateway) Start(addr string) {
 	router.GET("/ipns/:root", g.ipnsHandler)
 	router.GET("/ipns/:root/*path", g.ipnsHandler)
 
+	router.GET("/", g.cafeHandler)
 	router.GET("/cafe", g.cafeHandler)
 	router.GET("/cafes", g.cafesHandler)
 
@@ -137,12 +137,6 @@ func (g *Gateway) Addr() string {
 // ipfsHandler renders and optionally decrypts data behind an IPFS address
 func (g *Gateway) ipfsHandler(c *gin.Context) {
 	contentPath := c.Param("root") + c.Param("path")
-
-	// ignore the last file extension in path
-	parts := util.SplitString(contentPath, ".")
-	if len(parts) > 1 {
-		contentPath = strings.Join(parts[:len(parts)-1], ".")
-	}
 
 	data := g.getDataAtPath(c, contentPath)
 	if data == nil {


### PR DESCRIPTION
We had previously tried to handle path suffixes, allowing the user to specify a file extension, but (obviously) this messes up links that have real file extensions. 